### PR TITLE
Add support for Basic HTTP Auth

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -52,6 +52,7 @@ cradle.Connection = function Connection(/* variable args */) {
         host = args[0];
         port = parseInt(args[1]);
         options = args[2] || {};
+        auth = options.auth;
     }
 
     this.host = host || cradle.host;


### PR DESCRIPTION
Added 'Authorization' header when 'auth' option is passed into cradle.Connection
