### PR TITLE
A patch for DBCS support

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -151,7 +151,7 @@ cradle.Connection.prototype.request = function (method, path, /* [options], [dat
                 return val.toString();
             } else { return val }
         });
-        headers["Content-Length"] = data.length;
+        headers["Content-Length"] = Buffer.byteLength(data);
         headers["Content-Type"]   = "application/json";
     }
 

--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -368,6 +368,14 @@ vows.describe("Cradle").addBatch({
                         "which can be queried": status(200)
                     }
                 },
+                "with including DBCS chars": {
+                   topic: function (db){
+                      db.save('dbcs', {
+                         name: "ボブ"  // 'bob' in DBCS chars
+                      }, this.callback);
+                   },
+                   "creates a new document (201)": status(201)
+                },
                 "without an id (POST)": {},
             },
             "calling save() with an array": {


### PR DESCRIPTION
I found a DBCS issue in your library.

When cradle saves the document which includes DBCS field, CouchDB resturns 'invalid UTF-8'. It is because 'Content-Length' header is not correct.

The 'Content-Length' header is set using length property of the String object, but it is is not correct when the string includes DBCS chars. Buffer.byteLength should be used in such case.

I commit a patch and a test case for this issue, and 
I hope this patch helps the DBCS support.

Thanks.
