### PR TITLE
Fix wrong content length when using non-ASCII data

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -6,7 +6,8 @@ var sys = require("sys"),
    http = require("http"),
  events = require('events'),
      fs = require("fs"),
-    url = require('url');
+    url = require('url'),
+ buffer = require('buffer');
 
 var querystring = require('querystring');
 var Args = require('vargs').Constructor;
@@ -151,7 +152,7 @@ cradle.Connection.prototype.request = function (method, path, /* [options], [dat
                 return val.toString();
             } else { return val }
         });
-        headers["Content-Length"] = data.length;
+        headers["Content-Length"] = Buffer.byteLength(data);
         headers["Content-Type"]   = "application/json";
     }
 

--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -333,6 +333,12 @@ vows.describe("Cradle").addBatch({
                         assert.ok(res.rev);
                     }
                 },
+                "with a doc containing non-ASCII characters": {
+                    topic: function(db) {
+                        db.save('john', {umlauts: 'äöü'}, this.callback);
+                    },
+                    "creates a new document (201)": status(201)
+                },
                 "with a large doc": {
                     topic: function (db) {
                         var text = (function (s) {


### PR DESCRIPTION
Hi,

While trying to save data with German umlauts I got the following error: <code>{"error":"bad_request","reason":"invalid UTF-8 JSON"}</code>. The reason for this error is a wrong content length. The patch fixes this issue.
