### PR TITLE
Fixauth

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -28,6 +28,7 @@ cradle.options = {
 
 cradle.setup = function (settings) {
     this.host = settings.host;
+    this.auth = settings.auth;
     this.port = parseInt(settings.port);
     cradle.merge(this.options, settings);
 


### PR DESCRIPTION
putting the auth object on `this` seems to help when I try to use a non admin-party couch.

Thanks!

Chris
