### PR TITLE
Support for _update methods

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -4,6 +4,7 @@ require.paths.unshift(path.join(__dirname, 'cradle'));
 
 var sys = require("sys"),
    http = require("http"),
+   https = require("https"),
  events = require('events'),
      fs = require("fs"),
     url = require('url');
@@ -22,7 +23,8 @@ cradle.port = 5984;
 cradle.options = {
     cache: true,
     raw: false,
-    timeout: 0
+    timeout: 0,
+    ssl: false
 };
 
 cradle.setup = function (settings) {
@@ -62,8 +64,7 @@ cradle.Connection = function Connection(/* variable args */) {
     this.auth = auth || cradle.auth;
     this.options = cradle.merge({}, cradle.options, options);
 
-    this.socket = http.createClient(this.port, this.host);
-    this.socket.setTimeout(options.timeout);
+    this.socket = (options.ssl) ? https : http;
 };
 
 //
@@ -97,7 +98,15 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
         path += '?' + querystring.stringify(options);
     }
 
-    request = this.socket.request(method.toUpperCase(), path, headers);
+    var o = {
+      host: this.host,
+      port: this.port,
+      method: method.toUpperCase(),
+      path: path,
+      headers: headers
+    }
+
+    request = this.socket.request(o);
 
     if (data && data.addListener) { headers['Transfer-Encoding'] = 'chunked' }
 


### PR DESCRIPTION
Added support for _update handler methods (http://wiki.apache.org/couchdb/Document_Update_Handlers)

An example update might be:

"updates": {
  "modified": function(doc, req) {
      var date = req.query.date;
      var name = req.query.name;

```
  var message = "set name & modified to " + [name, date].join(',');
  doc['name'] = name;
  doc['modified'] = date;
  return [doc, message];
}
```

}

Say the design document was called 'Foo', you would call it like this:

db.update("Foo/modified", doc.id, {"name":"Bar", "date": new Date().toString()}, function(error, message) {})
