### PR TITLE
Added support for querying views with multiple keys

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -451,12 +451,21 @@ cradle.Connection.prototype.database = function (name) {
             var args = new(Args)(arguments);
             path = path.split('/');
 
+            var isMultikey = false;
             if (typeof(options) === 'object') {
                 ['key', 'startkey', 'endkey'].forEach(function (k) {
                     if (k in options) { options[k] = JSON.stringify(options[k]) }
                 });
+
+                isMultikey = (options.keys != null);
             }
-            this.query('GET', ['_design', path[0], '_view', path[1]].join('/'), options, args.callback);
+
+            if (isMultikey == false) {
+                this.query('GET', ['_design', path[0], '_view', path[1]].join('/'), options, args.callback);
+            }
+            else {
+                this.query('POST', ['_design', path[0], '_view', path[1]].join('/'), {}, options, args.callback);
+            }
         },
 
         // Query a list, passing any options to the query string.


### PR DESCRIPTION
If the 'options' object includes a 'keys' key, the request is sent using POST and the 'options' sent via the body instead of the URI query.
