### PR TITLE
Added support for creating views with URL escape codes

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -304,7 +304,7 @@ cradle.Connection.prototype.database = function (name) {
                 // PUT a single document, with an id (Create or Update)
                 if (id) {
                     // Design document
-                    if (/^_design\/\w+$/.test(id) && !('views' in doc)) {
+                    if (/^_design\/(\w|%)+$/.test(id) && !('views' in doc)) {
                         document.language = "javascript";
                         document.views    =  doc;
                     } else {


### PR DESCRIPTION
AFAIK, just using \w will not accept something with a URL escape code.  I just changed the Regex where that is determined to accept the \w or the %.  I think this should cover all of the bases.
