### PR TITLE
Added Content-Type header to viewCleanup() requests

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -438,7 +438,9 @@ cradle.Connection.prototype.database = function (name) {
                        {}, {}, headers, Args.last(arguments));
         },
         viewCleanup: function (callback) {
-            this.query('POST', '/_view_cleanup', callback);
+            var headers = {};
+            headers['Content-Type'] = "application/json";
+            this.query('POST', '/_view_cleanup', {}, {}, headers, callback);
         },
         allBySeq: function (options) {
             options = typeof(options) === 'object' ? options : {};


### PR DESCRIPTION
Added missing Content-Type header in viewCleanup() queries. Without this CouchDB complains about headers not being set to 'application/json'.
