### PR TITLE
When deleting a document, ensure that the Content-Length header is set.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -182,6 +182,10 @@ cradle.Connection.prototype.request = function (method, path, /* [options], [dat
         headers["Content-Type"]   = "application/json";
     }
 
+    if (method === "DELETE" && headers["Content-Length"] === undefined) {
+        headers["Content-Length"] = 0;
+    }
+
     request = this.rawRequest(method, path, options, data, headers);
 
     //


### PR DESCRIPTION
When you have a setup like: node/cradle <-> nginx <-> couchdb, HTTP DELETEs fail because the Content-Length header isn't set, and nginx insists upon it.

This patch seems to fix the problem for me.
