### PR TITLE
Fixed missing _id property on cached documents

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -375,7 +375,7 @@ cradle.Connection.prototype.database = function (name) {
             var cache = this.cache;
             if (typeof(id) !== 'string') { throw new(TypeError)("id must be a string") }
             this.query('PUT', id, null, doc, function (e, res) {
-                if (! e) { cache.save(id, cradle.merge({}, doc, { _rev: res.rev })) }
+                if (! e) { cache.save(id, cradle.merge({}, doc, { _id: id, _rev: res.rev })) }
                 callback && callback(e, res);
             });
         },
@@ -386,7 +386,7 @@ cradle.Connection.prototype.database = function (name) {
         post: function (doc, callback) {
             var cache = this.cache;
             this.query('POST', '/', null, doc, function (e, res) {
-                if (! e) { cache.save(res.id, cradle.merge({}, doc, { _rev: res.rev })) }
+                if (! e) { cache.save(res.id, cradle.merge({}, doc, { _id: res.id, _rev: res.rev })) }
                 callback && callback(e, res);
             });
         },

--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -114,6 +114,14 @@ vows.describe("Cradle").addBatch({
                 assert.ok(db.cache.has('bob'));
                 assert.ok(db.cache.get('bob')._rev);
             },
+            "when fetching the cached document": {
+                topic: function(db) {
+                    db.get('bob', this.callback)
+                },
+                "document contains _id": function(e, doc) {
+                    assert.equal(doc._id, 'bob');
+                }
+            },
             "and": {
                 topic: function (db) {
                     var promise = new(events.EventEmitter);


### PR DESCRIPTION
Hi,

When saving documents the _id property was not stored into cache, but when the document is loaded from the db the _id property is set.

This patch fixes the difference, so the _id property is always in the document.
