### PR TITLE
exposes HTTPResponse object to _changes promise so it can be killed when using continuous mode.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -319,7 +319,8 @@ cradle.Connection.prototype.database = function (name) {
             // Bulk Insert
             if (Array.isArray(doc)) {
                 document.docs = doc;
-                if (options.allOrNothing) { document.all_or_nothing = true }
+                if (options.overrideDocuments) { document.new_edits      = false }
+                if (options.allOrNothing)      { document.all_or_nothing = true  }
                 this.query('POST', '/_bulk_docs', {}, document, callback);
             } else {
                 // PUT a single document, with an id (Create or Update)


### PR DESCRIPTION
Fixes #GH-52. Exposes the response object, through the _changes promise, explicitly. This allows you to call response.socket.destroy() to kill the socket explicitly without destroying the running node process.
