### PR TITLE
Added limit to possible options for querying a view

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -468,7 +468,7 @@ cradle.Connection.prototype.database = function (name) {
             path = ['_design', path[0], '_view', path[1]].join('/');
 
             if (typeof(options) === 'object') {
-                ['key', 'startkey', 'endkey'].forEach(function (k) {
+                ['key', 'startkey', 'endkey', 'limit'].forEach(function (k) {
                     if (k in options) { options[k] = JSON.stringify(options[k]) }
                 });
             }


### PR DESCRIPTION
In the current module, you can only use key, startkey, and endkey when querying a view. I found myself needed to use limit, so I added it. There's a lot more options [here](http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options) that maybe should be added as well. Thoughts?
