### PR TITLE
Catch 'error' event on the socket.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -140,6 +140,12 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
         promise.emit('end');
     });
 
+    // To catch ECONNREFUSED
+    this.socket.on('error', function (err) {
+        promise.emit('error', err);
+        promise.emit('end');
+    });
+
 
     if (data) {
         if (data.on) {


### PR DESCRIPTION
This prevents the whole process from terminating on ECONNREFUSED. (Related discussion in Node.js: https://github.com/joyent/node/issues/136)
