### PR TITLE
Minor fix for zero length content header

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -303,6 +303,10 @@ cradle.Connection.prototype.database = function (name) {
             }
             this._save(id, rev, doc, args.callback);
         },
+		bulkinsert: function( document, callback )
+		{
+			this.query('POST', '/_bulk_docs', {}, document, callback);
+		},
        _save: function (id, rev, doc, callback) {
             var options = connection.options;
             var document = {}, that = this;


### PR DESCRIPTION
Removed the test against the DELETE verb when checking to add a zero content length header.

See https://github.com/cloudhead/cradle/issues/72
