### PR TITLE
typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ _Defaults to `127.0.0.1:5984`_
 Note that you can also use `cradle.setup` to set a global configuration:
 
     cradle.setup({host: 'living-room.couch',
-                  options: {cache: true, raw: false}});
+                  cache: true, raw: false});
     var c = new(cradle.Connection),
        cc = new(cradle.Connection)('173.45.66.92');
 


### PR DESCRIPTION
Fixed a typo in the section about cradle.setup.  The previous way would not change the cache parameter.
