### PR TITLE
Keep connections alive properly

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -118,6 +118,17 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
         path += '?' + querystring.stringify(options);
     }
 
+    if (headers['Connection'] === undefined) {
+        // Keep the connection alive but set timeout to close the socket after 5 seconds of inactivity
+        headers['Connection'] = 'keep-alive';
+        if (this.connectionTimeout !== undefined) {
+          clearTimeout(this.connectionTimeout);
+        }
+        this.connectionTimeout = setTimeout(function() {
+          that.close();
+        }, 5000);
+    }
+
     request = this.socket.request({
         host:    this.host,
         port:    this.port,
@@ -127,8 +138,6 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
     });
 
     if (data && data.on) { headers['Transfer-Encoding'] = 'chunked' }
-
-    headers['Connection'] = 'keep-alive';
 
     request.on('response', function (res) {
         promise.emit('response', res);
@@ -155,6 +164,19 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
 
     return promise;
 }
+
+//
+// Connection.close()
+//
+//      Close all underlying sockets associated with the agent for the connection.
+//
+cradle.Connection.prototype.close = function () {
+  var agent = this.socket.getAgent(this.host, this.port);
+  agent.sockets.forEach(function (socket) {
+      socket.end();
+  });
+}
+
 //
 // Connection.request()
 //


### PR DESCRIPTION
The Connection: keep-alive header should be set before making the HTTP/S request.

The default timeout of two minutes for closing underlying socket connections is too long, so the commit also explicitly closes the underlying sockets after 5 seconds of inactivity. This is also required for Node.js to properly exit as CouchDB holds onto a keep-alive connection indefinitely (vs Apache dropping it after 5-15 seconds).
