### PR TITLE
Added basic test for db.viewCleanup()

### DIFF
--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -606,6 +606,16 @@ vows.describe("Cradle").addBatch({
                     },
                     "returns a 404": status(404)
                 }
+            },
+            "cleaning up a view with viewCleanup()": {
+              topic: function (db) {
+                db.viewCleanup(this.callback);
+              },
+              "returns a 202": status(202),
+              "no error is thrown and we get ok response": function (e, res) {
+                assert.ok(!e);
+                assert.ok(res && res.ok && res.ok === true);
+              }
             }
         }
     }


### PR DESCRIPTION
Added a basic test for db.viewCleanup() in test/cradle-test.js as it wasn't being invoked at all in the tests so far.

Btw, I'd be more than happy to write more tests for cradle using vows. Where would be the right place to discuss this?

Cheers,

Lupo
