### PR TITLE
Changes feed may cause JSON parse errors.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -143,6 +143,7 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
         promise.emit('response', res);
         res.on('data', function (chunk) { promise.emit('data', chunk) });
         res.on('end',  function () { promise.emit('end') });
+        res.on('close', function(err) { promise.emit('error', err); });
     });
     request.on('error', function (err) {
         promise.emit('error', err);
@@ -564,6 +565,8 @@ cradle.Connection.prototype.database = function (name) {
                     }).on('end', function () {
                         response.emit('end');
                     });
+                }).on('error', function(error) {
+                    promise.emit('error', error);
                 });
                 return promise;
             }


### PR DESCRIPTION
In the current code, it is possible for JSON parse errors to occur because the "chunks" arriving from couchdb may be assembled incorrectly. In particular, the scenario I saw was:

chunk1: "{ ... valid JSON doc ... }"
chunk2: "\n"
chunk3: "{ ... valid JSON doc ....}\n"

Ie. the line return for the first object is in chunk2... however, because chunk2 only contains whitespace, it is ignored. So the buffer that is processed contains two JSON objects, which is invalid. 

The submitted change fixes this issue.
