### PR TITLE
Save _id to cache documents

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -397,7 +397,7 @@ cradle.Connection.prototype.database = function (name) {
             var cache = this.cache;
             if (typeof(id) !== 'string') { throw new(TypeError)("id must be a string") }
             this.query('PUT', id.split('/').map(querystring.escape).join('/'), null, doc, function (e, res) {
-                if (! e) { cache.save(id, cradle.merge({}, doc, { _rev: res.rev })) }
+                if (! e) { cache.save(id, cradle.merge({}, doc, { _rev: res.rev, _id: res.id })) }
                 callback && callback(e, res);
             });
         },
@@ -408,7 +408,7 @@ cradle.Connection.prototype.database = function (name) {
         post: function (doc, callback) {
             var cache = this.cache;
             this.query('POST', '/', null, doc, function (e, res) {
-                if (! e) { cache.save(res.id, cradle.merge({}, doc, { _rev: res.rev })) }
+                if (! e) { cache.save(res.id, cradle.merge({}, doc, { _rev: res.rev, _id: res.id })) }
                 callback && callback(e, res);
             });
         },


### PR DESCRIPTION
We were running into an issue where a (recently created) document retrieved from cradle did not include the id. We eventually realized that the problem didn't exist with caching disabled.

This commit populates the _id field in the cached document upon creation. Any reason to not have this?
