### PR TITLE
Added support for dash "-" to design doc name regexp.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -338,7 +338,7 @@ cradle.Connection.prototype.database = function (name) {
                 // PUT a single document, with an id (Create or Update)
                 if (id) {
                     // Design document
-                    if (/^_design\/(\w|%)+$/.test(id) && !('views' in doc)) {
+                    if (/^_design\/(\w|%|\-)+$/.test(id) && !('views' in doc)) {
                         document.language = "javascript";
                         document.views    =  doc;
                     } else {


### PR DESCRIPTION
I used the dash character a lot for design doc names. It is useful to namespace different kind of views.
Moreover, the dash is "url safe".
