### PR TITLE
reverse commit 10d303c224dbc7e63d8eab7fa297cb204f6de300

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -313,7 +313,7 @@ cradle.Connection.prototype.database = function (name) {
                 } else if (this.cache.has(id)) {
                     return args.callback(null, this.cache.get(id));
                 }
-                this.query('GET', id.split('/').map(querystring.escape).join('/'), options, function (err, res) {
+                this.query('GET', querystring.escape(id), options, function (err, res) {
                     if (! err) that.cache.save(res.id, res.json);
                     args.callback(err, res);
                 });


### PR DESCRIPTION
according to the couchdb docs[1], slashes in document ids
need to be url escaped just like any other special character.
The earlier commit escaped everything except slashes.  This
commit reverses that change so that all special characters
are appropriately escaped.

1: http://wiki.apache.org/couchdb/HTTP_Document_API#Document_IDs
