### PR TITLE
Support setting a connection's port via the URL string

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -52,6 +52,11 @@ cradle.Connection = function Connection(/* variable args */) {
             auth = options.auth;
         } else {
             host = a;
+
+            if (match = host.match(/^(.+)\:(\d{2,5})$/)) {
+                host = match[1];
+                port = parseInt(match[2]);
+            }
         }
     });
 
@@ -82,7 +87,7 @@ cradle.Connection = function Connection(/* variable args */) {
         host: this.host,
         port: this.port
     });
-    
+
     this.agent.maxSockets = this.options.maxSockets;
 };
 
@@ -124,7 +129,7 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
 
     //
     // ** Remark (indexzero): ** Keep-alive is causing unexpected hangups in tests
-    // removing it temporarily as we move forward towards a `request` based implementation. 
+    // removing it temporarily as we move forward towards a `request` based implementation.
     //
     // if (headers['Connection'] === undefined) {
     //     // Keep the connection alive but set timeout to close the socket after 5 seconds of inactivity
@@ -136,7 +141,7 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
     //       that.close();
     //     }, 5000);
     // }
-    
+
     request = this.socket.request({
         agent:   this.agent,
         host:    this.host,
@@ -581,7 +586,7 @@ cradle.Connection.prototype.database = function (name) {
                 }).on('error', function (err) {
                     promise.emit('error', err);
                 });
-                
+
                 return promise;
             }
         },

--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -90,6 +90,15 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                 assert.equal(c.port, 5984);
             }
         },
+        "with the port as part of the URL": {
+            topic: function () { return new(cradle.Connection)("https://couch.io:418") },
+            "should read the port from the URL": function (c) {
+                assert.equal(c.protocol, 'https');
+                assert.equal(c.options.secure, true);
+                assert.equal(c.host, 'couch.io');
+                assert.equal(c.port, 418);
+            }
+        }
     },
 }).addBatch({
     //
@@ -306,7 +315,7 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
     "Connection": {
         topic: function () {
             return new(cradle.Connection)('127.0.0.1', 5984, {cache: false});
-        },      
+        },
         "create()": {
             topic: function (c) {
                 c.database('badgers').create(this.callback);


### PR DESCRIPTION
Helpful for configuration, especially for environments where you're getting a URL passed via the environment (such as Heroku)
