### PR TITLE
Fix issue #43, added keys support to list

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -521,8 +521,7 @@ cradle.Connection.prototype.database = function (name) {
         // Query a list, passing any options to the query string.
         // Some query string parameters' values have to be JSON-encoded.
         list: function (path, options) {
-            var args = new(Args)(arguments),
-                path, keys;
+            var args = new(Args)(arguments), keys;
 
             path = path.split('/');
             path = ['_design', path[0], '_list', path[1], path[2]].map(querystring.escape).join('/');
@@ -543,8 +542,8 @@ cradle.Connection.prototype.database = function (name) {
         },
 
         update: function (path, id, options) {
-            var args = new(Args)(arguments),
-                path = path.split('/');
+            var args = new(Args)(arguments);
+            path = path.split('/');
 
             if (id) {
               this.query('PUT', ['_design', path[0], '_update', path[1], id].map(querystring.escape).join('/'), options, args.callback);


### PR DESCRIPTION
Dear Mr Cloudhead Sir,

I've added keys support to the list function and fixed up keys with parameters (avoiding having to encode them into the url) as per issue #43.
The tests for cradle don't seem to be working, not sure if this is me or the project. So this change is highly tested of course. Might want to do a quick run to verify.

Thanks!
