### PR TITLE
[test] Change `assert.length` to `assert.lengthOf`

### DIFF
--- a/test/cache-test.js
+++ b/test/cache-test.js
@@ -19,7 +19,7 @@ vows.describe('cradle/Cache').addBatch({
 
         'should be able to store 8 keys': function (topic) {
             for (var i = 0; i < 8; i++) { topic.save(i.toString(), {}) }
-            assert.length (Object.keys(topic.store), 8);
+            assert.lengthOf (Object.keys(topic.store), 8);
         },
         'if more than 8 keys are set': {
             topic: function (cache) {
@@ -30,7 +30,7 @@ vows.describe('cradle/Cache').addBatch({
                 });
             },
             'there should still be 8 keys in the store': function (cache) {
-                assert.length (Object.keys(cache.store), 8);
+                assert.lengthOf (Object.keys(cache.store), 8);
             }
         },
         'if an extra 8 keys are set': {
@@ -67,10 +67,10 @@ vows.describe('cradle/Cache').addBatch({
                 }, 10);
             },
             'it should have the 3 accessed ones, with the 5 new ones': function (cache) {
-                assert.length (Object.keys(cache.store), 8);
-                assert.isTrue (cache.has('2'));
-                assert.isTrue (cache.has('5'));
-                assert.isTrue (cache.has('1'));
+                assert.lengthOf (Object.keys(cache.store), 8);
+                assert.isTrue   (cache.has('2'));
+                assert.isTrue   (cache.has('5'));
+                assert.isTrue   (cache.has('1'));
                 for (var i = 8; i < 13; i++) { cache.has(i.toString()) }
             }
         }

--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -278,7 +278,7 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                 "returns a 200": status(200),
                 "returns an array of UUIDs": function (uuids) {
                     assert.isArray(uuids);
-                    assert.length(uuids, 42);
+                    assert.lengthOf(uuids, 42);
                 }
             },
             "without count": {
@@ -287,7 +287,7 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                 "returns a 200": status(200),
                 "returns an array of UUIDs": function (uuids) {
                     assert.isArray(uuids);
-                    assert.length(uuids, 1);
+                    assert.lengthOf(uuids, 1);
                 }
             }
         },
@@ -497,7 +497,7 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                 },
                 "returns an iterable object with key/val pairs": function (res) {
                     assert.isArray(res);
-                    assert.length(res, 2);
+                    assert.lengthOf(res, 2);
                     res.forEach(function (k, v) {
                         assert.isObject(v);
                         assert.isString(k);
@@ -528,7 +528,7 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                 },
                 "returns an iterable object with key/val pairs": function (res) {
                     assert.isArray(res);
-                    assert.length(res, 2);
+                    assert.lengthOf(res, 2);
                     res.forEach(function (k, v) {
                         assert.isObject(v);
                         assert.isString(k);

--- a/test/response-test.js
+++ b/test/response-test.js
@@ -15,7 +15,7 @@ vows.describe('cradle/Response').addBatch({
             topic: new(cradle.Response)(document),
 
             'should only have the original keys': function (topic) {
-                assert.length    (Object.keys(topic), 4);
+                assert.lengthOf  (Object.keys(topic), 4);
                 assert.equal     (topic.name, 'buzz');
                 assert.equal     (topic.age, 99);
                 assert.deepEqual (document, topic);
@@ -29,15 +29,15 @@ vows.describe('cradle/Response').addBatch({
                 assert.deepEqual   (topic.json, document);
                 assert.isUndefined (topic.json.json);
                 assert.isUndefined (topic.headers);
-                assert.length      (Object.keys(topic.json), 4);
+                assert.lengthOf    (Object.keys(topic.json), 4);
             },
             'when using a `for .. in` loop, should only return the original keys': function (topic) {
                 var keys = [];
                 for (var k in topic) { keys.push(k) }
 
-                assert.length  (keys, 4);
-                assert.include (keys, 'name');
-                assert.include (keys, 'age');
+                assert.lengthOf (keys, 4);
+                assert.include  (keys, 'name');
+                assert.include  (keys, 'age');
             },
             'should stringify': function (topic) {
                 var expected = JSON.stringify(document);


### PR DESCRIPTION
`vows@0.5.12` changes syntax from `assert.length` to `assert.lengthOf`.
