### PR TITLE
[fix] Fetching multiple documents from a view with include_docs=true fails

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -510,7 +510,9 @@ cradle.Connection.prototype.database = function (name) {
             }
 
             if (options && options.keys) {
-                this.query('POST', path, {}, options, args.callback);
+                var keys = options.keys;
+                delete options.keys;
+                this.query('POST', path, options, {keys:keys}, args.callback);
             } else {
                 this.query('GET', path, options, args.callback);
             }


### PR DESCRIPTION
When trying to fetch multiple documents from a view with 

```
{ keys: [array, of, keys], include_docs:true }
```

the "include_docs" option was ignored by the database. Fetching single documents worked fine. 
The current code submitted all options as params of the post request, but the documentation here:
https://wiki.apache.org/couchdb/HTTP_Bulk_Document_API suggests only the keys should be submitted as part of the post request, and the other options should be tacked onto the url get-style.
