### PR TITLE
Handle CouchDb 301 redirect on encoded design doc ids

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -149,6 +149,19 @@ cradle.Connection.prototype.rawRequest = function (method, path, options, data, 
     if (data && data.on) { headers['Transfer-Encoding'] = 'chunked' }
 
     request.on('response', function (res) {
+        if (res.statusCode === 301) {
+            // Redirect to URL in Location field
+            // Assumes same server (ignores host/auth/port/protocol in Location)
+            // Forwards events to original promise
+            var loc = url.parse(res.headers.location),
+                p = that.rawRequest(method, loc.pathname+(loc.search || ''),
+                        null, data, headers);
+            ['response', 'data', 'error', 'end'].forEach(function(ev) {
+                p.on(ev, function() { promise.emit.apply(promise,
+                    [ev].concat(Array.prototype.slice.call(arguments))) });
+            });
+            return;
+        }
         promise.emit('response', res);
         res.on('data', function (chunk) { promise.emit('data', chunk) });
         res.on('end',  function () { promise.emit('end') });

--- a/test/cradle-test.js
+++ b/test/cradle-test.js
@@ -593,6 +593,18 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                         assert.ok(res.rev);
                         assert.match(res.rev, /^1-/);
                     }
+                },
+                "to a design document": {
+                    topic: function (db) {
+                        var callback = this.callback;
+                        db.get('_design/pigs', function (err, doc) {
+                            db.saveAttachment('_design/pigs', doc.rev, 'farm/pen/foo.txt', 'text/plain', 'Foo!', callback);
+                        });
+                    },
+                    "returns a 201": status(201),
+                    "returns the revision": function (res) {
+                        assert.ok(res.rev);
+                    }
                 }
             },
             "getting an attachment": {
@@ -618,6 +630,32 @@ vows.describe("cradle").addBatch(seed.requireSeed()).addBatch({
                     },
                     "returns the attachment in the body": function (res) {
                         assert.equal(res.body, "hello world");
+                    }
+                },
+                "from a design document": {
+                    topic: function (db) {
+                        var promise = new(events.EventEmitter), response = {};
+                        doc = {_id:'_design/attachment-getter', _attachments:{
+                            "ranch/corral/foo.txt":{content_type:"text/plain", data:"cGxhbmV0YXJ5IGdyZWV0aW5ncw=="}
+                        }};
+                        db.save(doc, function (e, res) {
+                            var streamer = db.getAttachment('_design/attachment-getter','ranch/corral/foo.txt');
+                            streamer.addListener('response', function (res) {
+                                response.headers = res.headers;
+                                response.headers.status = res.statusCode;
+                                response.body = "";
+                            });
+                            streamer.addListener('data', function (chunk) { response.body += chunk; });
+                            streamer.addListener('end', function () { promise.emit('success', response); });
+                        });
+                        return promise;
+                    },
+                    "returns a 200": status(200),
+                    "returns the right mime-type in the header": function (res) {
+                        assert.equal(res.headers['content-type'], 'text/plain');
+                    },
+                    "returns the attachment in the body": function (res) {
+                        assert.equal(res.body, "planetary greetings");
                     }
                 },
                 "when not found": {


### PR DESCRIPTION
Fix for https://github.com/cloudhead/cradle/issues/117, added test.
