### PR TITLE
Avoid the JSON parse error on empty strings

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -567,9 +567,10 @@ cradle.Connection.prototype.database = function (name) {
                     res.on('data', function (chunk) {
                         var end;
                         if (~(end = chunk.indexOf('\n'))) {
-                            buffer.push(chunk.substr(0, ++end));
-                            buffer.length && response.emit('data', JSON.parse(buffer.join('')));
-                            buffer = [chunk.substr(end)];
+                            buffer.push(chunk.substr(0, end));
+                            var fragment = buffer.join('')
+                            if(fragment.length > 0) {response.emit('data', JSON.parse(fragment));}
+                            buffer = [chunk.substr(end+1)];
                         } else {
                             buffer.push(chunk);
                         }


### PR DESCRIPTION
The _changes feed from couchdb can return an empty string which cradle was trying to parse and causing a JSON parse error. This code joins the buffer fragments and test for string length > 0 before sending to JSON.
