### PR TITLE
Do I need to explicitly set the database url again on the changes feed?

### DIFF
--- a/lib/cradle/database/changes.js
+++ b/lib/cradle/database/changes.js
@@ -22,6 +22,10 @@ Database.prototype.changes = function (options, callback) {
     var feed = new follow.Feed(options),
         response = new events.EventEmitter(),
         responded = false;
+
+    if( !(options && options.db) ){
+      feed.db = 'http://' + this.connection.host + ':' + this.connection.port + '/' + this.name;
+    }
     
     //
     // Remark: Support the legacy `data` events. 


### PR DESCRIPTION
I seems when using changes you need to redefine the database url again the way follow does it? Hope I didn't miss something obvious. 
