### PR TITLE
ReferenceError: headers is not defined

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -113,7 +113,7 @@ cradle.Connection.prototype.rawRequest = function (options, callback) {
 
     // Set HTTP Basic Auth
     if (this.auth) {
-        headers['Authorization'] = "Basic " + new Buffer(this.auth.username + ':' + this.auth.password).toString('base64');
+        options.headers['Authorization'] = "Basic " + new Buffer(this.auth.username + ':' + this.auth.password).toString('base64');
     }
 
     // Set client-wide headers


### PR DESCRIPTION
Not sure if this is the case just for me or everyone with the recent changes, but this change fixed it for me.

``` bash
ReferenceError: headers is not defined
    at Connection.rawRequest (/home/locker/node_modules/cradle/lib/cradle.js:116:9)
    at Connection.request (/home/locker/node_modules/cradle/lib/cradle.js:179:17)
    at [object Object].query (/home/locker/node_modules/cradle/lib/cradle/database/index.js:15:21)
    at [object Object].exists (/home/locker/node_modules/cradle/lib/cradle/database/index.js:19:10)
    at /home/locker/database.js:41:13
    at Array.forEach (native)
    at Object.configure (/home/locker/database.js:30:13)
    at HTTPSServer.<anonymous> (/home/locker/mvc.js:98:14)
    at HTTPSServer.configure (/home/locker/node_modules/express/lib/http.js:542:61)
    at bootApplication (/home/locker/mvc.js:84:7)
```
