### PR TITLE
Fix to make binary attachments come down correctly.

### DIFF
--- a/lib/cradle/database/attachments.js
+++ b/lib/cradle/database/attachments.js
@@ -10,7 +10,8 @@ Database.prototype.getAttachment = function (id, attachmentName, callback) {
     
     return this.connection.rawRequest({
         method: 'GET', 
-        path: '/' + [this.name, querystring.escape(id), attachmentName].join('/')
+        path: '/' + [this.name, querystring.escape(id), attachmentName].join('/'),
+        encoding: null
     }, callback);
 };
 


### PR DESCRIPTION
I was having a problem with the body of binary attachments coming down as strings rather than buffers. This seems to fix it because the `encoding:null` option makes request return a buffer instead of a string.

I tried running the unit tests, but it seems like they're not entirely stable at the moment. Let me know if the tests should be working and I'll have another go.
