### PR TITLE
Only attempt to parseInt(settings.port) in cradle.setup if settings.port is defined

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -28,7 +28,9 @@ cradle.options = {
 cradle.setup = function (settings) {
     this.host = settings.host;
     this.auth = settings.auth;
-    this.port = parseInt(settings.port, 10);
+    if (settings.port) {
+      this.port = parseInt(settings.port, 10);
+    }
     cradle.merge(this.options, settings);
 
     return this;


### PR DESCRIPTION
This should fix issue #160 .
