### PR TITLE
remove allBySeq() documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,6 @@ Other API methods
 
 - `info()`: Database information
 - `all()`: Get all documents
-- `allBySeq()`: Get all documents by sequence
 - `compact()`: Compact database
 - `viewCleanup()`: Cleanup old view data
 - `replicate(target, options)`: Replicate this database to `target`.


### PR DESCRIPTION
README.md refers to a database method .allBySeq() which doesn't appear to exist
