### PR TITLE
Allow CouchDB servers specified with a port number in the URL string. 

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -52,7 +52,7 @@ cradle.Connection = function Connection(/* variable args */) {
             port = parseInt(a);
         } else if (typeof(a) === 'object') {
             options = a;
-            host = host || options.host;
+            host = host || options.hostname;
             port = port || options.port;
             auth = options.auth;
         } else {


### PR DESCRIPTION
Otherwise, cradle would make requests that are `/:5985/database`
