### PR TITLE
Accept url.parse() as options

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -65,6 +65,14 @@ cradle.Connection = function Connection(/* variable args */) {
         }
     });
 
+    if(typeof auth == "string") {
+        // probaby via a url.parse()
+        var userpass = auth.split(":");
+        auth = {};
+        auth.username = userpass[0];
+        auth.password = userpass[1] || null;
+    }
+
     this.host    = host || cradle.host;
     this.port    = port || cradle.port;
     this.auth    = auth || cradle.auth;


### PR DESCRIPTION
I'd like to propose that the options for configuring a cradle instance should use an `url` object verbatim instead of doing custom option parsing, but I also see why that might be a problematic BC breaking change. Accordingly, here's a small patch that shouldn't break BC, but get us one step closer towards just being able to pass an `url` object.
