### PR TITLE
Fixing changes() documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Changes API
 For a one-time `_changes` query, simply call `db.changes` with a callback:
 
 ``` js
-  db.changes(function (list) {
+  db.changes(function (err, list) {
       list.forEach(function (change) { console.log(change) });
   });
 ```
@@ -320,7 +320,7 @@ For a one-time `_changes` query, simply call `db.changes` with a callback:
 Or if you want to see changes since a specific sequence number:
 
 ``` js
-  db.changes({ since: 42 }, function (list) {
+  db.changes({ since: 42 }, function (err, list) {
       ...
   });
 ```


### PR DESCRIPTION
Ran into this with a Cloudant customer. They thought the Cloudant changes feed didn't work with Cradle, but they just weren't invoking the function properly.

Updated to show that the first parameter is "err".

Cheers.
