### PR TITLE
Fix Couchdb response metadata handling

### DIFF
--- a/lib/cradle/response.js
+++ b/lib/cradle/response.js
@@ -7,31 +7,38 @@
 this.Response = function Response(json, response) {
     var obj, headers;
 
-    // If there's rows, this is the result
-    // of a view function.
-    // We want to return this as an Array.
-    if (json.rows) {
-        obj           = json.rows.slice(0);
-        obj.__proto__ = new(Array);
-        if (json && typeof json === 'object') {
-            Object.keys(json).forEach(function (k) {
-                Object.defineProperty(obj.__proto__, k, {
-                    value:      json[k],
-                    enumerable: false
+    // If there's an _id key, it's the result
+    // of a document retrieval.
+    // Avoid potential key collisions.
+    if (!json._id) {
+        // If there's rows, this is the result
+        // of a view function.
+        // We want to return this as an Array.
+        if (json.rows) {
+            obj           = json.rows.slice(0);
+            obj.__proto__ = new(Array);
+            if (json && typeof json === 'object') {
+                Object.keys(json).forEach(function (k) {
+                    Object.defineProperty(obj.__proto__, k, {
+                        value:      json[k],
+                        enumerable: false
+                    });
                 });
-            });
+            }
+        } else if (json.results) {
+            obj = json.results.slice(0);
+            obj.__proto__ = new(Array);
+            obj.last_seq  = json.last_seq;
+        } else if (json.uuids) {
+            obj           = json.uuids;
+            obj.__proto__ = new(Array);
+        } else if (Array.isArray(json)) {
+            obj           = json.slice(0);
+            obj.__proto__ = new(Array);
         }
-    } else if (json.results) {
-        obj = json.results.slice(0);
-        obj.__proto__ = new(Array);
-        obj.last_seq  = json.last_seq;
-    } else if (json.uuids) {
-        obj           = json.uuids;
-        obj.__proto__ = new(Array);
-    } else if (Array.isArray(json)) {
-        obj           = json.slice(0);
-        obj.__proto__ = new(Array);
-    } else {
+    }
+
+    if (!obj) {
         obj           = {};
         obj.__proto__ = new(Object);
         if (json && typeof json === 'object') {

--- a/test/fixtures/databases.json
+++ b/test/fixtures/databases.json
@@ -14,7 +14,8 @@
     },
     { 
       "_id": "mike",
-      "color": "pink" 
+      "color": "pink",
+      "results": "none"
     },
     { 
       "_id": "bill",
@@ -37,7 +38,8 @@
     },
     { 
       "_id": "mike",
-      "color": "pink" 
+      "color": "pink",
+      "rows": 0
     },
     { 
       "_id": "bill",


### PR DESCRIPTION
If a Couchdb document contains a key named `results`, `rows`, or `uuids`, Cradle will crash or silently fail if you use the get() method to retrieve it. This is because Cradle attempts to detect the type of Couchdb response by the presence of a key with one of these names. Since the Couchdb GET response puts all the document keys into the same "namespace" as its metadata for other responses, a collision is inevitable.

This patch takes the presence of an `_id` key in the response as the signal that it's a document, in which case all the keys are part of the document and not metadata.

Patch also adds fields with metadata names to test data.

Addendum: for search purposes, here are two crash error messages in response.js that could occur attempting to get() a document containing a metadata key:

TypeError: Object #<Object> has no method 'slice'
TypeError: Object.defineProperty called on non-object
