### PR TITLE
Passing contentLength option for attachment. Useful for piped streams us...

### DIFF
--- a/lib/cradle/database/attachments.js
+++ b/lib/cradle/database/attachments.js
@@ -85,6 +85,10 @@ Database.prototype.saveAttachment = function (doc, attachment, callback) {
             || attachment['Content-Type'] 
             || 'text/plain'
     };
+
+    if (attachment['contentLength']) {
+        options.headers['Content-Length'] = attachment['contentLength'];
+    }
     
     if (attachment.body) {
         options.body = attachment.body;


### PR DESCRIPTION
Reverse proxies such as nginx require strict HTTP `Content-Length`. This is supported only when passing a `body`, but apparently not when using `fs.createReadStream(file).pipe(stream);`

This PR brings the options to explicitly set the HTTP `Content-Length` by using a `contentLength` option.
