### PR TITLE
Cradle automatically disarms CouchDB failsafe (conflict management) on .save()

### DIFF
--- a/lib/cradle/database/documents.js
+++ b/lib/cradle/database/documents.js
@@ -132,7 +132,9 @@ Database.prototype._save = function (id, rev, doc, callback) {
                 // Attempt to create a new document. If it fails,
                 // because an existing document with that _id exists (409),
                 // don't try to do anything funny in the dark.
-                callback(e, res);
+                this.put(id, document, function (e, res) {
+                  callback(e, res);
+                });
             }
         // POST a single document, without an id (Create)
         } else {


### PR DESCRIPTION
CouchDB leverages revision ids to assure a document nerver gets accidentally overwritten. On each update, the app logic must be aware of the previous revision id to update a document. Cradles .save() implementation completely disables this functionality, by automatically fetching the current documents revision id when a conflict occurs.
