### PR TITLE
tolerant view parameter in view method

### DIFF
--- a/lib/cradle/database/views.js
+++ b/lib/cradle/database/views.js
@@ -20,7 +20,12 @@ Database.prototype.view = function (path, options, callback) {
         options = {};
     }
 
-    path = path.split('/');
+    path = function(path) {
+      path = path.split('/');
+      path[0] !== '' || path.shift();
+      path[2] !== '' || path.pop();
+      return path;
+    }(path);
     path = ['_design', path[0], '_view', path[1]].map(querystring.escape).join('/');
 
     return this._getOrPostView(path, options, callback);

--- a/test/database-view-test.js
+++ b/test/database-view-test.js
@@ -65,6 +65,24 @@ vows.describe('cradle/database/view').addBatch(
                 },
                 ['mike', 'bill'],
                 3
+            ),
+            'with leading slashes': shouldQueryView(
+                function(db) {
+                    db.view('/pigs/all', this.callback);
+                },
+                ['bill','mike','alex']
+            ),
+            'with trailing slashes': shouldQueryView(
+                function(db) {
+                    db.view('pigs/all/', this.callback);
+                },
+                ['bill','mike','alex']
+            ),
+            'with leading and trailing slashes': shouldQueryView(
+                function(db) {
+                    db.view('/pigs/all/', this.callback);
+                },
+                ['bill','mike','alex']
             )
         },
         // same as the above test, but with a temporary view


### PR DESCRIPTION
Cradle accesses couch views with its own  shorter notation - omitting _design and _view url parts of the real couch query url.
The user of cradle might stumble upon this feature and provide views with leading or trailing slashes which lead to errors.

This implementation allows to call view() with leading and trailing slashes to reduce unnecessary errors in view calls.
