### PR TITLE
[api] If caching is turned off and we try to remove a document, try to get the _rev from couch

### DIFF
--- a/lib/cradle/database/documents.js
+++ b/lib/cradle/database/documents.js
@@ -194,22 +194,39 @@ Database.prototype.update = function (path, id, options) {
 };
 
 // Delete a document
-// if the _rev wasn't supplied, we attempt to retrieve it from the
-// cache. If the deletion was successful, we purge the cache.
+// If the _rev wasn't supplied, we attempt to retrieve it from the
+// cache. Otherwise, we attempt to get the _rev first. If the deletion
+// was successful, we purge the cache.
 Database.prototype.remove = function (id, rev) {
     var that = this, doc, args = new(Args)(arguments);
 
     if (typeof(rev) !== 'string') {
-        if (doc = this.cache.get(id)) { rev = doc._rev }
-        else                          { throw new(Error)("rev needs to be supplied") }
+        if (doc = this.cache.get(id)) {
+            rev = doc._rev;
+        }
+        else {
+            that.get(id, function (err, _doc) {
+                if (err) {
+                    return args.callback(err);
+                }
+                if (_doc._rev) {
+                    rev = _doc._rev;
+                    remove();
+                }
+            });
+        }
     }
-    
-    this.query({
-        method: 'DELETE', 
-        path: cradle.escape(id), 
-        query: { rev: rev }
-    }, function (err, res) {
-        if (! err) { that.cache.purge(id) }
-        args.callback(err, res);
-    });
+
+    remove();
+
+    function remove() {
+        that.query({
+            method: 'DELETE',
+            path: cradle.escape(id),
+            query: { rev: rev }
+        }, function (err, res) {
+            if (! err) { that.cache.purge(id) }
+            args.callback(err, res);
+        });
+    }
 };


### PR DESCRIPTION
Should take care of https://github.com/cloudhead/cradle/issues/215 . Tests pass but I don't think they cover cacheless use. This sort of logic has been working for me, though.
