### PR TITLE
Database.list support other-design-doc couch-9.4.13

### DIFF
--- a/lib/cradle/database/views.js
+++ b/lib/cradle/database/views.js
@@ -86,8 +86,14 @@ Database.prototype.list = function (path, options) {
     var callback = new(Args)(arguments).callback;
         path = path.split('/');
 
+    if (path.length < 4) {
+        path = ['_design', path[0], '_list', path[1], path[2]].map(querystring.escape).join('/');
+    } else {
+        path = ['_design', path[0], '_list', path[1], path[2], path[3]].map(querystring.escape).join('/');
+    }
+
     this._getOrPostView(
-        ['_design', path[0], '_list', path[1], path[2]].map(querystring.escape).join('/'),
+        path,
         options,
         callback
     );


### PR DESCRIPTION
Couch supports two types of API calls for lists
9.4.15.  /db/_design/design-doc/_list/list-name/view-name
[9.4.13.  /db/_design/design-doc/_list/list-name/other-design-doc/view-name](http://docs.couchdb.org/en/latest/api/design.html#get-db-design-design-doc-list-list-name-other-design-doc-view-name)

This pull request adds support for the latter
