### PR TITLE
Return request on database querying

### DIFF
--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -12,7 +12,7 @@ var Database = exports.Database = function (name, connection) {
 // which prepends the database name.
 Database.prototype.query = function (options, callback) {
     options.path = [this.name, options.path].filter(Boolean).join('/');
-    this.connection.request(options, callback);
+    return this.connection.request(options, callback);
 };
 
 Database.prototype.exists = function (callback) {


### PR DESCRIPTION
db query() function returns undefined instead of request object. This prevents from using streaming like this:

```
db.view(...).pipe(writeStream);
```
