### PR TITLE
Support for sending a body or a form to document update handlers

### DIFF
--- a/lib/cradle/database/documents.js
+++ b/lib/cradle/database/documents.js
@@ -178,23 +178,19 @@ Database.prototype.update = function (path, id, options) {
     var args = new(Args)(arguments);
     path = path.split('/');
 
-    var queryOptions = id? {
+    if (id) {
+      return this.query({
         method: 'PUT', 
         path: ['_design', path[0], '_update', path[1], id].map(querystring.escape).join('/'), 
         query: options
-    } : {
+      }, args.callback);
+    } 
+    
+    return this.query({
         method: 'POST', 
         path: ['_design', path[0], '_update', path[1]].map(querystring.escape).join('/'), 
         query: options, 
-    }
-
-    if(options.body) {
-        queryOptions.body = options.body;
-    } else if(options.form) {
-        queryOptions.form = options.form;
-    }
-    
-    return this.query(queryOptions, args.callback);
+    }, args.callback);
 };
 
 // Delete a document

--- a/lib/cradle/database/documents.js
+++ b/lib/cradle/database/documents.js
@@ -177,20 +177,24 @@ Database.prototype.insert = function () {
 Database.prototype.update = function (path, id, options) {
     var args = new(Args)(arguments);
     path = path.split('/');
-
-    if (id) {
-      return this.query({
+    
+    var queryOptions = id? {
         method: 'PUT', 
         path: ['_design', path[0], '_update', path[1], id].map(querystring.escape).join('/'), 
         query: options
-      }, args.callback);
-    } 
-    
-    return this.query({
+    } : {
         method: 'POST', 
         path: ['_design', path[0], '_update', path[1]].map(querystring.escape).join('/'), 
-        query: options, 
-    }, args.callback);
+        query: options
+    }
+    
+    if(options.body && typeof options.body == 'object') {
+        queryOptions.body = options.body;
+    } else if(options.form && typeof options.form == 'object') {
+        queryOptions.form = options.form;
+    }
+
+    return this.query(queryOptions, args.callback);
 };
 
 // Delete a document

--- a/test/database-update-test.js
+++ b/test/database-update-test.js
@@ -59,7 +59,7 @@ vows.describe('cradle/database/update').addBatch(
                     assert.equal(req.query.array, '');
                 }
             },
-            "called with a simple body option": {
+            "called with a simple 'body' option": {
                 topic: function(db) {
                     db.update('pigs/echo', null, { body:"I am the body" }, this.callback);
                 }
@@ -67,26 +67,30 @@ vows.describe('cradle/database/update').addBatch(
                 "receives empty request body": function(req) {
                     assert.equal(req.body, '');
                 },
-                "receives 'body' query parameter": function(req) {
+                "correctly receives the option as a query parameter": function(req) {
                     assert.ok(req.query.body)
                     assert.equal(req.query.body, "I am the body");
                 }
             },
-            "called with a (deep) complex body option": {
+            "called with a (deep) complex 'body' option": {
                 topic: function(db) {
                     db.update('pigs/echo', null, { body:fullObject }, this.callback);
                 }
                 ,
-                "{FAIL} receives a json-encoded body string in the request": function(req) {
-                    assert.ok(req.body);
-                    assert.equal(req.body, JSON.stringify(fullObject));
+                "receives a json-encoded request": function(req) {
+                    assert.ok(req.headers['Content-Type'] == 'application/json'
+                    || req.headers['Content-type'] == 'application/json');
                 },
-                "receives empty 'body' query parameter": function(req) {
+                "correctly receives the body object in the request": function(req) {
+                    assert.ok(req.body);
+                    assert.deepEqual(JSON.parse(req.body), fullObject);
+                },
+                "receives a empty 'body' query parameter": function(req) {
                     assert.ok(req.query)
                     assert.equal(req.query.body, '');
                 }
             },
-            "called with a simple form option": {
+            "called with a simple 'form' option": {
                 topic: function(db) {
                     db.update('pigs/echo', null, { form:"I am the form" }, this.callback);
                 }
@@ -94,22 +98,27 @@ vows.describe('cradle/database/update').addBatch(
                 "does not receive a parsed form object in the request": function(req) {
                     assert.deepEqual(req.form, {});
                 },
-                "receives 'form' query parameter": function(req) {
+                "correctly receives the options as a query parameter": function(req) {
                     assert.ok(req.query.form)
                     assert.equal(req.query.form, "I am the form");
                 }
             },
-            "called with a (shallow) complex form option": {
+            "called with a (shallow) complex 'form' option": {
                 topic: function(db) {
                     db.update('pigs/echo', null, { form:flatObject }, this.callback);
                 }
                 ,
-                "{FAIL} receives a parsed form object in the request": function(req) {
+                "receives a x-www-form-urlencoded request": function(req) {
+                    assert.ok(
+                        req.headers['Content-Type'].indexOf('application/x-www-form-urlencoded') == 0
+                     || req.headers['Content-type'].indexOf('application/x-www-form-urlencoded') == 0
+                    );
+                },
+                "correctly receives the form object in the request": function(req) {
                     assert.ok(req.form);
                     assert.deepEqual(req.form, flatObject);
                 },
                 "receives empty 'form' query parameter": function(req) {
-                    assert.ok(req.query.form);
                     assert.equal(req.query.form, '');
                 }
             }

--- a/test/database-update-test.js
+++ b/test/database-update-test.js
@@ -34,14 +34,14 @@ vows.describe('cradle/database/update').addBatch(
                     db.update('pigs/echo', null, flatObject, this.callback);
                 }
                 ,
-                "receives options as query params": function(req) {
+                "receives all options as query parameters": function(req) {
                     assert.ok(req.query);
                     assert.deepEqual(req.query, flatObject);
                 },
-                "receives empty body": function(res) {
+                "receives empty body string": function(res) {
                     assert.equal(res.body, '');
                 },
-                "receives empty form": function(res) {
+                "receives empty form object": function(res) {
                     assert.deepEqual(res.form, {});
                 }
             },
@@ -50,21 +50,69 @@ vows.describe('cradle/database/update').addBatch(
                     db.update('pigs/echo', null, fullObject, this.callback);
                 }
                 ,
-                "does not receive parameters": function(req) {
-                    assert.notDeepEqual(req.query, fullObject);
+                "receives only simple option values as query parameters": function(req) {
+                    assert.ok(req.query.simple);
+                    assert.equal(req.query.simple, fullObject.simple);
+                },
+                "receives complex options as empty query parameters": function(req) {
+                    assert.equal(req.query.complex, '');
+                    assert.equal(req.query.array, '');
+                }
+            },
+            "called with a simple body option": {
+                topic: function(db) {
+                    db.update('pigs/echo', null, { body:"I am the body" }, this.callback);
+                }
+                ,
+                "receives empty request body": function(req) {
+                    assert.equal(req.body, '');
+                },
+                "receives 'body' query parameter": function(req) {
+                    assert.ok(req.query.body)
+                    assert.equal(req.query.body, "I am the body");
+                }
+            },
+            "called with a (deep) complex body option": {
+                topic: function(db) {
+                    db.update('pigs/echo', null, { body:fullObject }, this.callback);
+                }
+                ,
+                "{FAIL} receives a json-encoded body string in the request": function(req) {
+                    assert.ok(req.body);
+                    assert.equal(req.body, JSON.stringify(fullObject));
+                },
+                "receives empty 'body' query parameter": function(req) {
+                    assert.ok(req.query)
+                    assert.equal(req.query.body, '');
+                }
+            },
+            "called with a simple form option": {
+                topic: function(db) {
+                    db.update('pigs/echo', null, { form:"I am the form" }, this.callback);
+                }
+                ,
+                "does not receive a parsed form object in the request": function(req) {
+                    assert.deepEqual(req.form, {});
+                },
+                "receives 'form' query parameter": function(req) {
+                    assert.ok(req.query.form)
+                    assert.equal(req.query.form, "I am the form");
+                }
+            },
+            "called with a (shallow) complex form option": {
+                topic: function(db) {
+                    db.update('pigs/echo', null, { form:flatObject }, this.callback);
+                }
+                ,
+                "{FAIL} receives a parsed form object in the request": function(req) {
+                    assert.ok(req.form);
+                    assert.deepEqual(req.form, flatObject);
+                },
+                "receives empty 'form' query parameter": function(req) {
+                    assert.ok(req.query.form);
+                    assert.equal(req.query.form, '');
                 }
             }
-        }/*,
-        "update() on void document": {
-            "passing a flat(untyped) object as form": shouldCallUpdate('pigs/parsing', null, {form: flatObject}, flatObject),
-            "passing a flat object in the body": shouldCallUpdate('pigs/parsing', null, {body: fullObject}, fullObject),
-            "passing a full object in the body": shouldCallUpdate('pigs/parsing', null, {body: fullObject}, fullObject),
-            "passing both a body and a form object(ignored)": shouldCallUpdate('pigs/parsing', null, {form:flatObject, body:fullObject}, fullObject)
-        }/*,
-        "update() on existing document": {
-            "passing a flat(untyped) object as form": shouldCallUpdate('pigs/parsing', 'mike', {form: flatObject}, flatObject),
-            "passing a flat object in the body": shouldCallUpdate('pigs/parsing', 'bill', {body: fullObject}, fullObject),
-            "passing a full object in the body": shouldCallUpdate('pigs/parsing', 'alex', {body: fullObject}, fullObject)
-        }*/
+        }
     })
 ).export(module);

--- a/test/database-update-test.js
+++ b/test/database-update-test.js
@@ -1,0 +1,70 @@
+var path = require('path'),
+    assert = require('assert'),
+    events = require('events'),
+    http = require('http'),
+    fs = require('fs'),
+    vows = require('vows'),
+    macros = require('./helpers/macros');
+
+var cradle = require('../lib/cradle');
+
+var flatObject = {
+    string: "Simple field",
+    boolean: "false",
+    number: "0"
+}
+
+var fullObject = {
+    simple: "Simple field",
+    complex: {
+        desc: "Complex object",
+        bool: false,
+        number: 0
+    },
+    array: [
+        "Array", { of: "objects" }
+    ]
+}
+
+vows.describe('cradle/database/update').addBatch(
+    macros.database({
+        "update() handler": {
+            "called with simple options": {
+                topic: function(db) {
+                    db.update('pigs/echo', null, flatObject, this.callback);
+                }
+                ,
+                "receives options as query params": function(req) {
+                    assert.ok(req.query);
+                    assert.deepEqual(req.query, flatObject);
+                },
+                "receives empty body": function(res) {
+                    assert.equal(res.body, '');
+                },
+                "receives empty form": function(res) {
+                    assert.deepEqual(res.form, {});
+                }
+            },
+            "called with complex options": {
+                topic: function(db) {
+                    db.update('pigs/echo', null, fullObject, this.callback);
+                }
+                ,
+                "does not receive parameters": function(req) {
+                    assert.notDeepEqual(req.query, fullObject);
+                }
+            }
+        }/*,
+        "update() on void document": {
+            "passing a flat(untyped) object as form": shouldCallUpdate('pigs/parsing', null, {form: flatObject}, flatObject),
+            "passing a flat object in the body": shouldCallUpdate('pigs/parsing', null, {body: fullObject}, fullObject),
+            "passing a full object in the body": shouldCallUpdate('pigs/parsing', null, {body: fullObject}, fullObject),
+            "passing both a body and a form object(ignored)": shouldCallUpdate('pigs/parsing', null, {form:flatObject, body:fullObject}, fullObject)
+        }/*,
+        "update() on existing document": {
+            "passing a flat(untyped) object as form": shouldCallUpdate('pigs/parsing', 'mike', {form: flatObject}, flatObject),
+            "passing a flat object in the body": shouldCallUpdate('pigs/parsing', 'bill', {body: fullObject}, fullObject),
+            "passing a full object in the body": shouldCallUpdate('pigs/parsing', 'alex', {body: fullObject}, fullObject)
+        }*/
+    })
+).export(module);

--- a/test/fixtures/updates.js
+++ b/test/fixtures/updates.js
@@ -1,0 +1,39 @@
+// Echo update handler to inspect update request object
+exports.echo = function(doc, req)
+{
+	return [null, toJSON(req)];
+}
+
+// Execute a document update passing a JSON object in the request body
+exports.parsing = function(doc, req)
+{
+	// Either update an existing document or create a new one
+	var doc = doc || { _id:req.uuid }
+	var res = {
+		ok: true,
+		id: doc._id,
+		inputType: req.headers['Content-Type'] || req.headers['Content-type'],
+		reqBody: req.query.body,
+		reqForm: req.query.form,
+		parsedInput: null
+	};
+	// If received and parsed a form
+	if(res.inputType.indexOf('application/x-www-form-urlencoded') == 0)
+	{	// Take the couchdb parsed object
+		res.parsedInput = req.form;
+	}
+	else if(res.inputType.indexOf('application/json') == 0)
+	{	// Otherwise try to parse the body as json
+		try {
+			res.parsedInput = JSON.parse(req.body);
+		} catch(err) {
+			return [null, toJSON({err:'bad_request', reason:err})];
+		}
+	}
+	// Straightly copy the values from the input into the document
+	for(var f in res.parsedInput) {
+		doc[f] = res.parsedInput[f];
+	}
+	// Save doc and return request info to the client
+	return [doc, toJSON(res)];
+}

--- a/test/helpers/seed.js
+++ b/test/helpers/seed.js
@@ -5,6 +5,7 @@ var assert = require('assert'),
     request = require('request');
     
 var databases = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'databases.json'), 'utf8'));
+var updates = require('../fixtures/updates.js');
 
 var seed = exports;
 
@@ -30,6 +31,10 @@ seed.seedDatabase = function (name, callback) {
     }
     
     function putDoc (doc, next) {
+      if(doc._id.indexOf('_design/') == 0) {
+        doc.updates = {}
+        for(var u in updates) doc.updates[u] = updates[u].toString();
+      }
       request({
         method: 'PUT',
         url: 'http://127.0.0.1:5984/' + encodeURIComponent(name) + '/' + doc._id,


### PR DESCRIPTION
I've added the option to pass a body or a form object through the `database.update()` helper.

If either `body` or `form` are defined in the options and are objects, they are encoded according to cradle's and request's underlying mechanisms (i.e. _application/json_ for body, and _application/x-www-form-urlencoded_ for form) and sent as the request body.

If they are defined but are not objects, update() behaves as usual and put them in the query string.

If body is used, form is ignored (that is, treated as a query parameter).

There are some basic test included.

(sorry for the messy commit log)
