### PR TITLE
Support for replication and lucene search for databases with special characters on name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 test/fixtures/README.md
 test/fixtures/not-found.txt
+.idea

--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -5,6 +5,7 @@ var querystring = require('querystring'),
 var Database = exports.Database = function (name, connection) {
     this.connection = connection;
     this.name = encodeURIComponent(name);
+    this.unEscapedName = name;
     this.cache = new (cradle.Cache)(connection.options);
 };
 
@@ -31,7 +32,7 @@ Database.prototype.exists = function (callback) {
 
 Database.prototype.replicate = function (target, options, callback) {
     if (typeof(options) === 'function') { callback = options, options = {} }
-    this.connection.replicate(cradle.merge({ source: decodeURIComponent(this.name), target: target }, options), callback);
+    this.connection.replicate(cradle.merge({ source: this.unEscapedName, target: target }, options), callback);
 };
 
 Database.prototype.info = function (callback) {

--- a/lib/cradle/database/views.js
+++ b/lib/cradle/database/views.js
@@ -33,7 +33,7 @@ Database.prototype.fti = function (path, options, callback) {
     }
 
     path = path.split('/');
-    path = ['_fti', 'local', decodeURIComponent(this.name), '_design', path[0], path[1]].map(querystring.escape).join('/');
+    path = ['_fti', 'local', this.unEscapedName, '_design', path[0], path[1]].map(querystring.escape).join('/');
 
     options = parseOptions(options);
 


### PR DESCRIPTION
Databases with special characters on name were double urlencoded on replication and lucene search. Added property for unescaped database name.
