### PR TITLE
Add CouchError to wrap REST errors in Error object

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -13,6 +13,7 @@ cradle.extend   = require('./cradle/response').extend;
 cradle.Response = require('./cradle/response').Response;
 cradle.Cache    = require('./cradle/cache').Cache;
 cradle.Database = require('./cradle/database').Database;
+cradle.CouchError = require('./cradle/errors').CouchError;
 
 cradle.host = '127.0.0.1';
 cradle.port = 5984;
@@ -218,7 +219,7 @@ cradle.Connection.prototype.request = function (options, callback) {
         else if (body && body.error) {
             cradle.extend(body, { headers: res.headers });
             body.headers.status = res.statusCode;
-            return callback(body);
+            return callback(new cradle.CouchError(body));
         }
       
         try { body = JSON.parse(body) }
@@ -227,7 +228,7 @@ cradle.Connection.prototype.request = function (options, callback) {
         if (body && body.error) {
             cradle.extend(body, { headers: res.headers });
             body.headers.status = res.statusCode;
-            return callback(body);
+            return callback(new cradle.CouchError(body));
         }
       
         callback(null, self.options.raw ? body : new cradle.Response(body, res));

--- a/lib/cradle/errors.js
+++ b/lib/cradle/errors.js
@@ -1,0 +1,25 @@
+var util = require('util');
+
+// create custom Error object for better callback(err, ...) support
+// accepts an JSON object from CouchDB's REST errors
+function CouchError (err) {
+	// ensure proper stack trace
+	Error.call(this);
+	Error.captureStackTrace(this, this.constructor);
+
+	this.name = this.constructor.name;
+	this.message = err.error + ': ' + err.reason;
+
+	// add properties from CouchDB error response to Error object
+	for (var k in err) {
+		if (err.hasOwnProperty(k)) {
+			this[k] = err[k];
+		}
+	}
+}
+// CouchError instanceof Error
+util.inherits(CouchError, Error);
+
+
+// export
+this.CouchError = CouchError;


### PR DESCRIPTION
Allows for proper handling of Error objects in callbacks (e.g. `throw err` and `next(err)`) and maintains all the existing properties of the original REST error for backwards compatibility.

``` js
db.view('some/view', function (err, res) {
  // errors extend the Error object
  err instanceof Error; // true

  // errors are now throwable
  if (err) throw err;

  // errors can also be used with Express.js to pass request to error handler
  if (err) return next(err);

  // ...
});
```

See #216 and #213.
