### PR TITLE
Copy headers to error object explicitly.

### DIFF
--- a/lib/cradle/errors.js
+++ b/lib/cradle/errors.js
@@ -16,6 +16,7 @@ function CouchError (err) {
 			this[k] = err[k];
 		}
 	}
+    this.headers = err.headers;
 }
 // CouchError instanceof Error
 util.inherits(CouchError, Error);


### PR DESCRIPTION
The way that cradle/response.extend works means the properties don't enumerate.
This causes tests which are checking status to fail (`macros.status` fails because `e.headers` is `undefined`).
With this fix, all tests pass for me.
