### PR TITLE
Made path concatenation normalized

### DIFF
--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -1,4 +1,5 @@
 var querystring = require('querystring'),
+    path = require('path'),
     Args = require('vargs').Constructor,
     cradle = require('../../cradle');
 
@@ -11,7 +12,7 @@ var Database = exports.Database = function (name, connection) {
 // A wrapper around `Connection.request`,
 // which prepends the database name.
 Database.prototype.query = function (options, callback) {
-    options.path = [this.name, options.path].filter(Boolean).join('/');
+    options.path = path.normalize([this.name, options.path].filter(Boolean).join('/'));
     return this.connection.request(options, callback);
 };
 


### PR DESCRIPTION
For example,  if trying to get all documents from database "beer-example" using following code
database.all(function (res) {
    console.log(res);
 });
The path will be concatenated as /beer-example//_all_docs, and syncGateway will return "NOT FOUND" error.
