### PR TITLE
Prevent 'db.view' function from modifying provided query options object.

### DIFF
--- a/lib/cradle/database/views.js
+++ b/lib/cradle/database/views.js
@@ -125,17 +125,18 @@ Database.prototype._getOrPostView = function (path, options, callback) {
 // to pass to CouchDB.
 //
 function parseOptions(options) {
+    var parsed = {};
+
     if (options && typeof options === 'object') {
         ['key', 'startkey', 'endkey'].forEach(function (k) {
-            if (k in options) { options[k] = JSON.stringify(options[k]) }
+            if (k in options) { parsed[k] = JSON.stringify(options[k]) }
         });
     }
 
     if (options && options.keys) {
-        options.body = options.body || {};
-        options.body.keys = options.keys;
-        delete options.keys;
+        parsed.body = options.body || {};
+        parsed.body.keys = options.keys;
     }
 
-    return options;
+    return parsed;
 }


### PR DESCRIPTION
db.view function modifies the passed-in options object which may lead to unexpected behaviour.

One case is when client code is using a reference to the same view options objects multiple times to query a view. This results in query options object differ from its original state yielding incorrect couchDB url string on consecutive calls to db.view function.

```
// E.g: stringifying params.key multiple times
var params = { key : 123 }
async.timesSeries( 5, function ( n, cb ) {
        db.view( 'design/view', params, function () { cb();});
}, function () {
        // params now equals to : {key: ""\"\\\"\\\\\\\"123\\\\\\\"\\\"\"""} 
});
```
