### PR TITLE
Fixes cradle.Connection.prototype.config

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -137,7 +137,10 @@ cradle.Connection.prototype.rawRequest = function (options, callback) {
     Object.keys(this.options.headers).forEach(function (header) {
         options.headers[header] = self.options.headers[header];
     });
-            
+    
+    // Set property server function for handling them special at the response wrapper
+    options.serverFunction = (['/', '/_all_dbs', '/_config', '/_uuids', '/_stats', '/_active_tasks'].indexOf(options.path))? options.path : false;
+    
     if (options.query && Object.keys(options.query).length) {
         for (var k in options.query) {
             if (typeof(options.query[k]) === 'boolean') {
@@ -232,7 +235,7 @@ cradle.Connection.prototype.request = function (options, callback) {
             return callback(new cradle.CouchError(body));
         }
       
-        callback(null, self.options.raw ? body : new cradle.Response(body, res));
+        callback(null, self.options.raw ? body : new cradle.Response(body, res, options.serverFunction));
     });
 };
 

--- a/lib/cradle/response.js
+++ b/lib/cradle/response.js
@@ -4,7 +4,7 @@
 //      It allows us to call array-like methods on documents
 //      with a 'row' attribute.
 //
-this.Response = function Response(json, response) {
+this.Response = function Response(json, response, serverFunction) {
     var obj, headers;
 
     // If there's an _id key, it's the result
@@ -29,7 +29,7 @@ this.Response = function Response(json, response) {
             obj = json.results.slice(0);
             obj.__proto__ = new(Array);
             obj.last_seq  = json.last_seq;
-        } else if (json.uuids) {
+        } else if (json.uuids && serverFunction === '/_uuids') {
             obj           = json.uuids;
             obj.__proto__ = new(Array);
         } else if (Array.isArray(json)) {


### PR DESCRIPTION
cradle.Connection.prototype.config returns only its property uuid, if it
exists inside the configuration of CouchDB.

The parsing of the property uuid at cradle.Response is now only used if
the server level function /_uuids was called.
