### PR TITLE
Added purge command for purging a document

### DIFF
--- a/lib/cradle/database/documents.js
+++ b/lib/cradle/database/documents.js
@@ -235,3 +235,40 @@ Database.prototype.remove = function (id, rev) {
 
     remove();
 };
+
+Database.prototype.purge = function(id, rev) {
+    var that = this, doc, args = new(Args)(arguments);
+    function purge() {
+        var body = {};
+        body[id] = [rev];
+        that.query({
+            method: 'POST',
+            path: '_purge',
+            body: body
+        }, function (err, res) {
+            if (! err) { that.cache.purge(id); }
+            args.callback(err, res);
+        });
+    }
+
+    if (typeof(rev) !== 'string') {
+        if (doc = this.cache.get(id)) {
+            rev = doc._rev;
+        }
+        else {
+            return this.get(id, function (err, _doc) {
+                if (err) {
+                    return args.callback(err);
+                }
+                else if (!_doc._rev) {
+                    return args.callback(new Error('No _rev found for ' + id));
+                }
+
+                rev = _doc._rev;
+                purge();
+            });
+        }
+    }
+
+    purge();
+};

--- a/test/database-test.js
+++ b/test/database-test.js
@@ -196,8 +196,20 @@ function shouldQueryCouch(name) {
                 return promise;
             },
             "returns a 200": macros.status(200)
-        }
-    }
+        },
+        "purging a document (PURGE)": {
+            topic: function (db) {
+                var promise = new(events.EventEmitter);
+                db.get('deleteme', function (e, res) {
+                    db.purge('deleteme', res.rev, function (e, res) {
+                        promise.emit('success', res);
+                    });
+                });
+                return promise;
+            },
+            "returns a 200": macros.status(200)
+        },
+    };
 }
 
 var cradle = require('../lib/cradle');


### PR DESCRIPTION
CouchDB does not remove a document permanently from DB after a remove() command call. A special, purge command must be used. It is not recommended to use daily - should be mainly used for security purposes such as erasing credit card numbers, however in my project I use it so I thought it should be in cradle for the API to be complete
