### PR TITLE
Fix validation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ when saving a design document, cradle guesses you want to create a view, mention
     validate_doc_update:
       function (newDoc, oldDoc, usrCtx) {
         if (! /^(light|dark|neutral)$/.test(newDoc.force))
-          throw { error: "invalid value", reason:"force must be dark, light, or neutral" }
+          throw({forbidden: {error: "invalid value", reason: "force must be dark, light, or neutral"}})
       }
     }
   });


### PR DESCRIPTION
Following [user report on SO](http://stackoverflow.com/questions/26846280/case-clause-error-couchdb-with-cradle/26846554?noredirect=1#comment42256712_26846554), given validation function forces CouchDB to return HTTP 500 response and crush internally:

```
[Mon, 10 Nov 2014 19:15:04 GMT] [error] [<0.303.0>] Uncaught error in HTTP request: {error,
                                                     {case_clause,
                                                      {[{<<"error">>,
                                                         <<"invalid value">>},
                                                        {<<"reason">>,
                                                         <<"force must be dark, light, or neutral">>}]}}}
[Mon, 10 Nov 2014 19:15:04 GMT] [info] [<0.303.0>] Stacktrace: [{couch_query_servers,validate_doc_update,5,
                                    [{file,"couch_query_servers.erl"},
                                     {line,227}]},
                                {couch_db,
                                    '-validate_doc_update/3-lc$^0/1-0-',5,
                                    [{file,"couch_db.erl"},{line,473}]},
                                {couch_db,validate_doc_update,3,
                                    [{file,"couch_db.erl"},{line,473}]},
                                {couch_db,prep_and_validate_update,5,
                                    [{file,"couch_db.erl"},{line,494}]},
                                {couch_db,
                                    '-prep_and_validate_updates/6-fun-2-',6,
                                    [{file,"couch_db.erl"},{line,561}]},
                                {lists,foldl,3,
                                    [{file,"lists.erl"},{line,1261}]},
                                {couch_db,prep_and_validate_updates,6,
                                    [{file,"couch_db.erl"},{line,559}]},
                                {couch_db,update_docs,4,
                                    [{file,"couch_db.erl"},{line,747}]}]
[Mon, 10 Nov 2014 19:15:04 GMT] [info] [<0.303.0>] 127.0.0.1 - - PUT /docs/54 500
[Mon, 10 Nov 2014 19:15:04 GMT] [error] [<0.303.0>] httpd 500 error response:
 {"error":"case_clause","reason":"{[{<<\"error\">>,<<\"invalid value\">>},\n  {<<\"reason\">>,<<\"force must be dark, light, or neutral\">>}]}"}
```

because `validate_doc_update` expected to throw only `{forbidden: ...}` or `{unauthorized: ...}` errors for HTTP 403 and HTTP 401 responses respectively.
