### PR TITLE
Fix JSHint errors. Enable strict mode.

### DIFF
--- a/lib/cradle/cache.js
+++ b/lib/cradle/cache.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var Response = require('./response').Response;
 //
 // Each database object has its own cache store.
@@ -16,10 +19,10 @@ this.Cache = function (options) {
 
 this.Cache.prototype = {
     // API
-    get:   function (id)      { return this.query('get',   id) },
-    save:  function (id, doc) { return this.query('save',  id, doc) },
-    purge: function (id)      { return this.query('purge', id) },
-    has:   function (id)      { return this.query('has',   id) },
+    get:   function (id)      { return this.query('get',   id); },
+    save:  function (id, doc) { return this.query('save',  id, doc); },
+    purge: function (id)      { return this.query('purge', id); },
+    has:   function (id)      { return this.query('has',   id); },
 
     _get: function (id) {
         var entry;
@@ -51,10 +54,12 @@ this.Cache.prototype = {
             this.prune();
         }
 
-        return this.store[id] = {
+        this.store[id] = {
             atime:    Date.now(),
             document: doc
         };
+
+        return this.store[id];
     },
     _purge: function (id) {
         if (id) {

--- a/lib/cradle/database/documents.js
+++ b/lib/cradle/database/documents.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var querystring = require('querystring'),
     Args = require('vargs').Constructor,
     cradle = require('../../cradle'),
@@ -28,12 +31,17 @@ Database.prototype.get = function (id, rev) {
             query: { include_docs: true },
             body: { keys: id },
         }, function (err, res) {
-            args.callback(err, res)
+            args.callback(err, res);
         });
     } else {
         if (rev && args.length === 2) {
-            if      (typeof(rev) === 'string') { options = { rev: rev } }
-            else if (typeof(rev) === 'object') { options = rev }
+            if (typeof(rev) === 'string') {
+                options = {
+                    rev: rev 
+                };
+            } else if (typeof(rev) === 'object') {
+                options = rev;
+            }
         } else if (this.cache.has(id)) {
             return args.callback(null, this.cache.get(id));
         }
@@ -52,13 +60,17 @@ Database.prototype.get = function (id, rev) {
 //
 Database.prototype.put = function (id, doc, callback) {
     var cache = this.cache;
-    if (typeof(id) !== 'string') { throw new(TypeError)("id must be a string") }
+    if (typeof(id) !== 'string') {
+        throw new(TypeError)("id must be a string");
+    }
     this.query({
         method: 'PUT',
         path: cradle.escape(id),
         body: doc
     }, function (e, res) {
-        if (! e) { cache.save(id, cradle.merge({}, doc, { _id: id, _rev: res.rev })) }
+        if (! e) {
+            cache.save(id, cradle.merge({}, doc, { _id: id, _rev: res.rev }));
+        }
         callback && callback(e, res);
     });
 };
@@ -73,7 +85,9 @@ Database.prototype.post = function (doc, callback) {
         path: '/',
         body: doc
     }, function (e, res) {
-        if (! e) { cache.save(res.id, cradle.merge({}, doc, { _id: res.id, _rev: res.rev })) }
+        if (! e) {
+            cache.save(res.id, cradle.merge({}, doc, { _id: res.id, _rev: res.rev }));
+        }
         callback && callback(e, res);
     });
 };
@@ -85,8 +99,8 @@ Database.prototype.save = function (/* [id], [rev], doc | [doc, ...] */) {
     if (Array.isArray(args.first)) {
         doc = args.first;
     } else {
-        doc = array.pop(),
-        id  = array.shift(),
+        doc = array.pop();
+        id  = array.shift();
         rev = array.shift();
     }
     this._save(id, rev, doc, args.callback);
@@ -99,7 +113,9 @@ Database.prototype._save = function (id, rev, doc, callback) {
     // Bulk Insert
     if (Array.isArray(doc)) {
         document.docs = doc;
-        if (options.allOrNothing) { document.all_or_nothing = true }
+        if (options.allOrNothing) {
+            document.all_or_nothing = true;
+        }
         this.query({
             method: 'POST',
             path: '/_bulk_docs',
@@ -135,14 +151,16 @@ Database.prototype._save = function (id, rev, doc, callback) {
                 this.put(id, document, function (e, res) {
                     if (e && e.headers && e.headers.status === 409 && options.forceSave) { // Conflict
                         that.head(id, function (e, headers, res) {
-                            if (res === 404 || !headers['etag']) {
+                            if (res === 404 || !headers.etag) {
                                 return callback({ reason: 'not_found' });
                             }
 
-                            document._rev = headers['etag'].slice(1, -1);
+                            document._rev = headers.etag.slice(1, -1);
                             that.put(id, document, callback);
                         });
-                    } else { callback(e, res) }
+                    } else {
+                        callback(e, res);
+                    }
                 });
             }
         // POST a single document, without an id (Create)
@@ -164,7 +182,9 @@ Database.prototype.merge = function (/* [id], doc */) {
 Database.prototype._merge = function (id, doc, callback) {
     var that = this;
     this.get(id, function (e, res) {
-        if (e) { return callback(e) }
+        if (e) {
+            return callback(e);
+        }
         doc = cradle.merge({}, res.json || res, doc);
         that.save(id, res._rev, doc, callback);
     });
@@ -214,7 +234,9 @@ Database.prototype.remove = function (id, rev) {
             path: cradle.escape(id),
             query: { rev: rev }
         }, function (err, res) {
-            if (! err) { that.cache.purge(id) }
+            if (! err) {
+                that.cache.purge(id);
+            }
             args.callback(err, res);
         });
     }

--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var querystring = require('querystring'),
     Args = require('vargs').Constructor,
     cradle = require('../../cradle');
@@ -30,7 +33,10 @@ Database.prototype.exists = function (callback) {
 };
 
 Database.prototype.replicate = function (target, options, callback) {
-    if (typeof(options) === 'function') { callback = options, options = {} }
+    if (typeof(options) === 'function') {
+        callback = options;
+        options = {};
+    }
     this.connection.replicate(cradle.merge({ source: this.name, target: target }, options), callback);
 };
 

--- a/lib/cradle/database/views.js
+++ b/lib/cradle/database/views.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var querystring = require('querystring'),
     Args = require('vargs').Constructor,
     cradle = require('../../cradle'),
@@ -48,7 +51,9 @@ Database.prototype.temporaryView = function (doc, options, callback) {
 
     if (options && typeof options === 'object') {
         ['key', 'keys', 'startkey', 'endkey'].forEach(function (k) {
-            if (k in options) { options[k] = JSON.stringify(options[k]) }
+            if (k in options) {
+                options[k] = JSON.stringify(options[k]);
+            }
         });
     }
 
@@ -118,7 +123,7 @@ Database.prototype._getOrPostView = function (path, options, callback) {
         path: path,
         query: options
     }, callback);
-}
+};
 
 //
 // Helper function for parsing and stringifying complex options
@@ -129,7 +134,9 @@ function parseOptions(options) {
         options = cradle.extend({}, options);
 
         ['key', 'startkey', 'endkey'].forEach(function (k) {
-            if (k in options) { options[k] = JSON.stringify(options[k]) }
+            if (k in options) {
+                options[k] = JSON.stringify(options[k]);
+            }
         });
     }
 

--- a/lib/cradle/errors.js
+++ b/lib/cradle/errors.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var util = require('util');
 
 // create custom Error object for better callback(err, ...) support

--- a/lib/cradle/response.js
+++ b/lib/cradle/response.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 //
 // HTTP response wrapper
 //
@@ -111,14 +114,14 @@ this.collectionPrototype = {
     map: function (f) {
         var ary = [];
         if (f.length === 1) {
-            this.forEach(function (a) { ary.push(f.call(this, a)) });
+            this.forEach(function (a) { ary.push(f.call(this, a)); });
         } else {
-            this.forEach(function () { ary.push(f.apply(this, arguments)) });
+            this.forEach(function () { ary.push(f.apply(this, arguments)); });
         }
         return ary;
     },
     toArray: function () {
-        return this.map(function (k, v) { return v });
+        return this.map(function (k, v) { return v; });
     }
 };
 


### PR DESCRIPTION
Fixed most, but not all JSHint warnings and errors for the following files:

 lib/cradle/cache.js
 lib/cradle/database/documents.js
 lib/cradle/database/index.js
 lib/cradle/database/views.js
 lib/cradle/errors.js
 lib/cradle/response.js
