### PR TITLE
Fix JSHint errors. Enable strict mode.

### DIFF
--- a/lib/cradle/database/attachments.js
+++ b/lib/cradle/database/attachments.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var querystring = require('querystring'),
     Args = require('vargs').Constructor,
     cradle = require('../../cradle'),
@@ -17,7 +20,8 @@ Database.prototype.getAttachment = function (id, attachmentName, callback) {
 Database.prototype.removeAttachment = function (doc, attachmentName, callback) {
     var params,
         rev,
-        id;
+        id,
+        error;
 
     if (typeof doc === 'string') {
         id = doc;
@@ -28,7 +32,9 @@ Database.prototype.removeAttachment = function (doc, attachmentName, callback) {
     
     if (!id) {
         error = new(TypeError)("first argument must be a document id");
-        if (!callback) { throw error }
+        if (!callback) {
+            throw error;
+        }
         return callback(error);
     }
     
@@ -63,13 +69,13 @@ Database.prototype.saveAttachment = function (doc, attachment, callback) {
 
     if (!id) {
         error = new(TypeError)("Missing document id.");
-        if (!callback) { throw error }
+        if (!callback) {
+            throw error;
+        }
         return callback(error);
     }
     
-    attachmentName = typeof attachment !== 'string'
-        ? attachment.name
-        : attachment;
+    attachmentName = typeof attachment !== 'string' ? attachment.name : attachment;
     
     if (!rev && this.cache.has(id)) {
         params = { rev: this.cache.get(id)._rev };
@@ -80,14 +86,14 @@ Database.prototype.saveAttachment = function (doc, attachment, callback) {
     options.method = 'PUT';
     options.path = '/' + [this.name, querystring.escape(id), attachmentName].join('/');
     options.headers = {
-        'Content-Type': attachment['content-type'] 
-            || attachment['contentType']
-            || attachment['Content-Type'] 
-            || 'text/plain'
+        'Content-Type': attachment['content-type'] ||
+            attachment.contentType ||
+            attachment['Content-Type'] ||
+            'text/plain'
     };
 
-    if (attachment['contentLength']) {
-        options.headers['Content-Length'] = attachment['contentLength'];
+    if (attachment.contentLength) {
+        options.headers['Content-Length'] = attachment.contentLength;
     }
     
     if (attachment.body) {
@@ -109,6 +115,7 @@ Database.prototype.saveAttachment = function (doc, attachment, callback) {
 
         if (result.headers.status == 201) {
             if (self.cache.has(id)) {
+                // FIXME: Is this supposed to be this.cached?
                 cached = self.cache.store[id].document;
                 cached._rev = result.rev;
                 cached._attachments = cached._attachments || {};

--- a/lib/cradle/database/changes.js
+++ b/lib/cradle/database/changes.js
@@ -1,3 +1,6 @@
+/*jshint node:true */
+"use strict";
+
 var events = require('events'),
     querystring = require('querystring'),
     Args = require('vargs').Constructor,
@@ -30,8 +33,7 @@ Database.prototype.changes = function (options, callback) {
     if (!options.db) {
         protocol = this.connection.protocol || 'http';
         
-        if (this.connection.auth && this.connection.auth.username
-            && this.connection.auth.password) {
+        if (this.connection.auth && this.connection.auth.username && this.connection.auth.password) {
             auth = this.connection.auth.username + ':' + this.connection.auth.password + '@';            
         }
         


### PR DESCRIPTION
Fix most JSHint errors in lib/cradle/database/attachments.js and lib/cradle/database/changes.js. Added a FIXME comment about use of non-declared 'cached' parameter.
