### PR TITLE
Support self signed ca certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,15 @@ Connecting with authentication and SSL
   });
 ```
 
+or 
+
+``` js
+  var connection = new(cradle.Connection)('https://couch.io', 443, {
+      auth: { username: 'john', password: 'fha82l' },
+      ca: fs.readFileSync('path_to_self_signed_ca.crt')
+  });
+```
+
 or
 
 ``` js

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Connecting with authentication and SSL
   });
 ```
 
-or 
+or providing a self signed CA certificate
 
 ``` js
   var connection = new(cradle.Connection)('https://couch.io', 443, {

--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -18,6 +18,7 @@ cradle.CouchError = require('./cradle/errors').CouchError;
 cradle.host = '127.0.0.1';
 cradle.port = 5984;
 cradle.auth = null;
+cradle.ca = null;
 cradle.options = {
     cache: true,
     raw: false,
@@ -48,6 +49,8 @@ cradle.Connection = function Connection(/* variable args */) {
         match,
         host, 
         port, 
+        ca,
+        agentOptions = {},
         auth;
 
     args.forEach(function (a) {
@@ -58,6 +61,7 @@ cradle.Connection = function Connection(/* variable args */) {
             host = host || options.hostname || options.host;
             port = port || options.port;
             auth = options.auth;
+            ca = options.ca;
         } else {
             host = a;
             
@@ -79,6 +83,7 @@ cradle.Connection = function Connection(/* variable args */) {
     this.host    = host || cradle.host;
     this.port    = port || cradle.port;
     this.auth    = auth || cradle.auth;
+    this.ca      = ca   || cradle.ca;
     this.options = cradle.merge({}, cradle.options, options);
 
     this.options.maxSockets = this.options.maxSockets || 20;
@@ -102,11 +107,17 @@ cradle.Connection = function Connection(/* variable args */) {
         console.log('Warning: "ssl" option is deprecated. Use "secure" instead.');
     }
 
-    this.transport = (this.options.secure) ? https : http;
-    this.agent = new (this.transport.Agent)({
-        host: this.host,
-        port: this.port
-    });
+    agentOptions.host = this.host;
+    agentOptions.port = this.port;
+    if (this.options.secure) {
+        this.transport = https;
+        if (this.ca) {
+            agentOptions.ca = this.ca;
+        }
+    } else {
+        this.transport = http;
+    }
+    this.agent = new (this.transport.Agent)(agentOptions);
     
     this.agent.maxSockets = this.options.maxSockets;
 };


### PR DESCRIPTION
Previously when the couchdb server uses a self signed certification,
the connection will abort with verify leaf signature error.
Now we can provide the root ca file as an option when creating cradle Connection.