### PR TITLE
 Avoid aliasing id & rev if prop names are already there

### DIFF
--- a/lib/cradle/response.js
+++ b/lib/cradle/response.js
@@ -69,9 +69,9 @@ this.Response = function Response(json, response) {
     }
 
     // Alias '_rev' and '_id'
-    if (obj.id && obj.rev) {
+    if (obj.id && obj.rev && !obj._id && !obj._rev) {
         exports.extend(obj, { _id:  obj.id, _rev: obj.rev });
-    } else if (obj._id && obj._rev) {
+    } else if (obj._id && obj._rev && !obj.id && !obj.rev) {
         exports.extend(obj, { id:  obj._id, rev: obj._rev });
     }
 

--- a/test/response-test.js
+++ b/test/response-test.js
@@ -83,6 +83,10 @@ vows.describe('cradle/response').addBatch({
 
             'should have preserved the original id value': function (topic) {
                 assert.equal(topic.id, '10009');
+            },
+
+            'should keep the id property enumerable': function (topic) {
+                assert(Object.keys(topic).indexOf('id') >= 0);
             }
         }
     }

--- a/test/response-test.js
+++ b/test/response-test.js
@@ -8,6 +8,14 @@ var path = require('path'),
 var cradle = require('../lib/cradle');
 var document = { _rev: '2-76be', _id: 'f6av8', name: 'buzz', age: 99 };
 
+var clone = function (o) { return JSON.parse(JSON.stringify(o)); };
+
+var extend = function (o, key, value) {
+    var result = clone(o);
+    result[key] = value;
+    return result;
+};
+
 vows.describe('cradle/response').addBatch({
     'A cradle.Response instance': {
         'from a document': {
@@ -67,6 +75,15 @@ vows.describe('cradle/response').addBatch({
                 }
             }
         }
+    },
+
+    'A tricky cradle.Response instance': {
+        'from a document with an id property': {
+            topic: new(cradle.Response)(extend(document, 'id', '10009')),
+
+            'should have preserved the original id value': function (topic) {
+                assert.equal(topic.id, '10009');
+            }
+        }
     }
 }).export(module);
-


### PR DESCRIPTION
Because of obscure historical reasons, we have an `id` property in our CouchDB documents. So, when one GET-s such a document with `curl`, they'll see something like:
    
    { _id: '811b77f35fca01bae6eb9b8ad67becc4',
      _rev: '1-c70b6027c1d75917cef89710a6ef02f0',
      id: '10001',
      name: 'Sorell Hotel Aarauerhof',
      ratingStars: 3,
      ...}
    
However, if we `get()` such a document with cradle, our `id` value disappears, becoming a non-enumerable property with a value of `811b77f...`. That change helps avoiding such a situation.
