### PR TITLE
Check if options.uri is already set, seems to be an issue with retries

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -160,7 +160,7 @@ cradle.Connection.prototype.rawRequest = function (options, callback) {
 
     options.headers['Connection'] = options.headers['Connection'] || 'keep-alive';
     options.agent = this.agent;
-    options.uri = this._url(options.path);
+    options.uri = (typeof options.uri == 'undefined') ? this._url(options.path) : options.uri;
     delete options.path;
 
     return request(options, callback || function () { });


### PR DESCRIPTION
There seems to be an issue with retries, to the point that it already has the options.uri and no options.path
- I assume because it gets deleted and options is being passed around