### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cradle",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "the high-level, caching, CouchDB library",
   "url": "http://cloudhead.io/cradle",
   "keywords": ["couchdb", "database", "couch"],


### PR DESCRIPTION
Release 0.7.0 will support self-signed certificates and fixes #285.