### PR TITLE
Added official MIT header to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2009 cloudhead
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
Added the official license header according to http://opensource.org/licenses/MIT. This will be of great help for preventing legal issues for users of this (awesome) library. Would be great if you can merge it.