### PR TITLE
Add a new cache mode 'follow'

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -253,8 +253,8 @@ cradle.Connection.prototype.request = function (options, callback) {
 //      We return an object with database functions,
 //      closing around the `name` argument.
 //
-cradle.Connection.prototype.database = function (name) {
-    return new cradle.Database(name, this)
+cradle.Connection.prototype.database = function (name, opts) {
+    return new cradle.Database(name, this, opts)
 };
 
 //

--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -6,6 +6,23 @@ var Database = exports.Database = function (name, connection) {
     this.connection = connection;
     this.name = encodeURIComponent(name);
     this.cache = new (cradle.Cache)(connection.options);
+
+    // For any entry already in the cache, update it if it changes
+    // remotely.
+    if (connection.options.cache === 'follow') {
+       var self = this;
+       this.changes(function (err, list) {
+          var lastSeq = 0;
+          if (list && list.length !== 0)
+             lastSeq = list[list.length - 1]["seq"];
+          var feed = self.changes({ since: lastSeq, include_docs: true });
+          feed.on('change', function (change) {
+             var id = change["id"];
+             if (id && 'doc' in change && self.cache.has(id))
+                self.cache.save(id, change["doc"]);
+          });
+       });
+    }
 };
 
 // A wrapper around `Connection.request`,

--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -6,22 +6,34 @@ var Database = exports.Database = function (name, connection) {
     this.connection = connection;
     this.name = encodeURIComponent(name);
     this.cache = new (cradle.Cache)(connection.options);
+    this.cacheFeed = null;
+    var self = this;
+    this.exists(function(err, result) {
+        if (result === true)
+            self.configureCacheFeed();
+    });
+};
 
+Database.prototype.configureCacheFeed = function () {
+    if (this.cacheFeed) {
+        this.cacheFeed.stop();
+        this.cacheFeed = null;
+    }
     // For any entry already in the cache, update it if it changes
     // remotely.
-    if (connection.options.cache === 'follow') {
-       var self = this;
-       this.changes(function (err, list) {
-          var lastSeq = 0;
-          if (list && list.length !== 0)
-             lastSeq = list[list.length - 1]["seq"];
-          var feed = self.changes({ since: lastSeq, include_docs: true });
-          feed.on('change', function (change) {
-             var id = change["id"];
-             if (id && 'doc' in change && self.cache.has(id))
-                self.cache.save(id, change["doc"]);
-          });
-       });
+    if (this.connection.options.cache === 'follow') {
+        var self = this;
+        this.changes(function (err, list) {
+            var lastSeq = 0;
+            if (list && list.length !== 0)
+                lastSeq = list[list.length - 1]["seq"];
+            self.cacheFeed = self.changes({ since: lastSeq, include_docs: true });
+            self.cacheFeed.on('change', function (change) {
+                var id = change["id"];
+                if (id && 'doc' in change && self.cache.has(id))
+                    self.cache.save(id, change["doc"]);
+            });
+        });
     }
 };
 
@@ -56,7 +68,11 @@ Database.prototype.info = function (callback) {
 };
 
 Database.prototype.create = function (callback) {
-    this.query({ method: 'PUT' }, callback);
+    var self = this;
+    this.query({ method: 'PUT' }, function () {
+        self.configureCacheFeed();
+        callback.apply(this, arguments);
+    });
 };
 
 // Destroys a database with 'DELETE'

--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -7,11 +7,13 @@ var Database = exports.Database = function (name, connection) {
     this.name = encodeURIComponent(name);
     this.cache = new (cradle.Cache)(connection.options);
     this.cacheFeed = null;
-    var self = this;
-    this.exists(function(err, result) {
-        if (result === true)
-            self.configureCacheFeed();
-    });
+    if (connection.options.cache === 'follow') {
+       var self = this;
+       this.exists(function(err, result) {
+           if (result === true)
+               self.configureCacheFeed();
+       });
+    }
 };
 
 Database.prototype.configureCacheFeed = function () {

--- a/lib/cradle/database/index.js
+++ b/lib/cradle/database/index.js
@@ -2,12 +2,17 @@ var querystring = require('querystring'),
     Args = require('vargs').Constructor,
     cradle = require('../../cradle');
 
-var Database = exports.Database = function (name, connection) {
+var Database = exports.Database = function (name, connection, opts) {
     this.connection = connection;
     this.name = encodeURIComponent(name);
-    this.cache = new (cradle.Cache)(connection.options);
+    this.opts = {...connection.options};
+    if (opts && opts.disableCache) {
+       this.opts.cache = false;
+       this.opts.cacheSize = 0;
+    }
+    this.cache = new (cradle.Cache)(this.opts);
     this.cacheFeed = null;
-    if (connection.options.cache === 'follow') {
+    if (this.opts.cache === 'follow') {
        var self = this;
        this.exists(function(err, result) {
            if (result === true)
@@ -23,7 +28,7 @@ Database.prototype.configureCacheFeed = function () {
     }
     // For any entry already in the cache, update it if it changes
     // remotely.
-    if (this.connection.options.cache === 'follow') {
+    if (this.opts.cache === 'follow') {
         var self = this;
         this.changes(function (err, list) {
             var lastSeq = 0;


### PR DESCRIPTION
Rather than specifying 'true' or 'false' for the 'cache' option,
specifying 'follow' will use a changes feed to track external
modification to cached documents.  Only documents that have been
cached during normal write-through operation will be updated.

This is useful if you have a system where multiple clients may write
directly to the database without going through a single cache.

Note: This could be made more optimal for cases where not all changes
in the feed are cached as it pulls the full document content in the
change feed.  Maybe a mode 'follow-lite' could enable a lightweight
change feed followed by additional fetch if it is found that a changed
document is cached.  If, for a particular app however, changes are
likely to occur externally to documents in the cache, the existing
'include_docs' mode is probably OK.
