### PR TITLE
Add the License type and upgrade repository entry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "engines": {
     "node": ">=0.8.0"
   },
-  "repository": "flatiron/cradle"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/flatiron/cradle.git"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
The main reason for the repository change is so the github link will show up properly on npmjs.org I know the previous value is legal but it doesnt seem to work right with npmjs.org.

I added the `license` value based on the LICENSE file because the newer versions of NPM are getting more strict on enforcing the license entry and complaining about it during installs.