### PR TITLE
Passthrough `request` options to `cradle` `rawRequest`.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -5,7 +5,11 @@ var events = require('events'),
     http = require('http'),
     https = require('https'),
     querystring = require('querystring'),
-    request = require('request');
+    request = require('request'),
+    _ = {
+      omit: require('lodash.omit'),
+      merge: require('lodash.merge')
+    };
 
 var cradle = exports;
 
@@ -64,8 +68,9 @@ cradle.Connection = function Connection(/* variable args */) {
             ca = options.ca;
         } else {
             host = a;
-            
-            if (match = host.match(/^(.+)\:(\d{2,5})$/)) {
+            match = host.match(/^(.+)\:(\d{2,5})$/);
+
+            if (match) {
                 host = match[1];
                 port = parseInt(match[2]);
             }
@@ -85,7 +90,6 @@ cradle.Connection = function Connection(/* variable args */) {
     this.auth    = auth || cradle.auth;
     this.ca      = ca   || cradle.ca;
     this.options = cradle.merge({}, cradle.options, options);
-
     this.options.maxSockets = this.options.maxSockets || 20;
     this.options.secure     = this.options.secure     || this.options.ssl;
 
@@ -135,20 +139,20 @@ cradle.Connection = function Connection(/* variable args */) {
 cradle.Connection.prototype.rawRequest = function (options, callback) {
     var promise = new(events.EventEmitter), 
         self = this;
-
+    
     // HTTP Headers
     options.headers = options.headers || {};
 
-    // Set HTTP Basic Auth
-    if (this.auth) {
-        options.headers['Authorization'] = "Basic " + new Buffer(this.auth.username + ':' + this.auth.password).toString('base64');
-    }
-
     // Set client-wide headers
-    Object.keys(this.options.headers).forEach(function (header) {
+    /*Object.keys(this.options.headers).forEach(function (header) {
         options.headers[header] = self.options.headers[header];
-    });
-            
+        });*/
+    var omittable = ['cache', 'raw', 'secure',
+                     'forceSave', 'retries', 'retryTimeout',
+                     'maxSockets', 'host', 'port', 'ca',
+                     'agent', 'transport'];
+    options = _.merge(options, _.omit(self.options, omittable));
+
     if (options.query && Object.keys(options.query).length) {
         for (var k in options.query) {
             if (typeof(options.query[k]) === 'boolean') {
@@ -175,7 +179,7 @@ cradle.Connection.prototype.close = function () {
   this.agent.sockets.forEach(function (socket) {
       socket.end();
   });
-}
+};
 
 //
 // Connection.request()
@@ -200,7 +204,7 @@ cradle.Connection.prototype.request = function (options, callback) {
         options.body = JSON.stringify(options.body, function (k, val) {
             if (typeof(val) === 'function') {
                 return val.toString();
-            } else { return val }
+            } else { return val; }
         });
         options.headers["Content-Length"] = Buffer.byteLength(options.body);
         options.headers["Content-Type"]   = "application/json";
@@ -234,7 +238,7 @@ cradle.Connection.prototype.request = function (options, callback) {
             return callback(new cradle.CouchError(body));
         }
       
-        try { body = JSON.parse(body) }
+        try { body = JSON.parse(body); }
         catch (err) { }
       
         if (body && body.error) {
@@ -254,7 +258,7 @@ cradle.Connection.prototype.request = function (options, callback) {
 //      closing around the `name` argument.
 //
 cradle.Connection.prototype.database = function (name) {
-    return new cradle.Database(name, this)
+    return new cradle.Database(name, this);
 };
 
 //
@@ -303,12 +307,11 @@ cradle.Connection.prototype._url = function (path) {
     
     url += path[0] === '/' ? path : ('/' + path);
     return url;
-}
+};
 
 cradle.escape = function (id) {
-    return ['_design', '_changes', '_temp_view'].indexOf(id.split('/')[0]) === -1
-        ? querystring.escape(id)
-        : id;
+  var shouldEscape = ['_design', '_changes', '_temp_view'].indexOf(id.split('/')[0]) === -1;
+    return shouldEscape ? querystring.escape(id) : id;
 };
 
 cradle.merge = function (target) {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,27 @@
   "version": "0.7.0",
   "description": "the high-level, caching, CouchDB library",
   "url": "http://cloudhead.io/cradle",
-  "keywords": ["couchdb", "database", "couch"],
+  "keywords": [
+    "couchdb",
+    "database",
+    "couch"
+  ],
   "author": "Alexis Sellier <self@cloudhead.net>",
   "contributors": [
-    { "name": "Charlie Robbins", "email": "charlie@nodejitsu.com" },
-    { "name": "Maciej Malecki", "email": "maciej@nodejitsu.com" }
+    {
+      "name": "Charlie Robbins",
+      "email": "charlie@nodejitsu.com"
+    },
+    {
+      "name": "Maciej Malecki",
+      "email": "maciej@nodejitsu.com"
+    }
   ],
   "main": "./lib/cradle",
   "dependencies": {
     "follow": "0.11.x",
+    "lodash.merge": "^3.3.2",
+    "lodash.omit": "^3.1.0",
     "request": "2.x.x",
     "vargs": "0.1.0"
   },


### PR DESCRIPTION
# :construction: Looking for feedback.

I had been having an issue where `cradle` was always sending the *Content-Length* header which, in some instances can cause problems if you're tunneling through a proxy. i.e. The proxy will complain with a 400 because *HTTP CONNECT* _shouldn't_ have a body.

It seemed to me there was no interface in `cradle` to help me in this situation, but `request` supports it. Since most of these CouchDB libraries are just facades for `request` and CouchDB I added some functionality to _pass through_ all non-`cradle` specific items to `request`.

I think it would also be worthwhile to simplify the constructor interface for connection in this regards, and be honest with ourselves and say, "Hey, it's just `request`, everyone knows `request`." Would love any feedback that could be offered.

Tests pending. Thanks!