### PR TITLE
options.auth passes straight through to request library.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -100,9 +100,6 @@ cradle.Connection = function Connection(/* variable args */) {
         this.protocol = (this.options.secure) ? 'https' : 'http';
     }
 
-    if (this.auth && this.auth.user) { // Deprecation warning
-        console.log('Warning: "user" & "pass" parameters ignored. Use "username" & "password"');
-    }
     if (this.options.ssl) { // Deprecation warning
         console.log('Warning: "ssl" option is deprecated. Use "secure" instead.');
     }
@@ -141,7 +138,7 @@ cradle.Connection.prototype.rawRequest = function (options, callback) {
 
     // Set HTTP Basic Auth
     if (this.auth) {
-        options.headers['Authorization'] = "Basic " + new Buffer(this.auth.username + ':' + this.auth.password).toString('base64');
+        options.auth = this.auth;
     }
 
     // Set client-wide headers


### PR DESCRIPTION
The reason to do this is so that we don't re-do the functionality that `request` has already made for us. This way users can use OAuth Tokens or any other authentication strategy supported by `request`, but still remains backwards compatible with the `cradle` API.

I'm in the midst of providing a `request` pass through option to open `cradle` up to the full functionality. Configuration in general could use a re-work, but would definitely lead to breaking changes in most areas. In my opinion, 90% of `cradle`'s configuration variables configure `request` and therefore `cradle` should pick off the values it _needs_ and just pass the rest to `request`.