### PR TITLE
Added logic to allow developers to utilize full request API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ Cradle's API builds right on top of Node's asynch API. Every asynch method takes
   new(cradle.Connection)('http://living-room.couch', 5984, {
       cache: true,
       raw: false,
-      forceSave: true
+      forceSave: true,
+      request: {
+        //Pass through configuration to `request` library for all requests on this connection.
+      }
   });
 ```
 

--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -162,7 +162,8 @@ cradle.Connection.prototype.rawRequest = function (options, callback) {
     options.agent = this.agent;
     options.uri = this._url(options.path);
     delete options.path;
-
+    options = cradle.merge(this.options.request, options);
+    
     return request(options, callback || function () { });
 };
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,21 @@
   "version": "0.7.0",
   "description": "the high-level, caching, CouchDB library",
   "url": "http://cloudhead.io/cradle",
-  "keywords": ["couchdb", "database", "couch"],
+  "keywords": [
+    "couchdb",
+    "database",
+    "couch"
+  ],
   "author": "Alexis Sellier <self@cloudhead.net>",
   "contributors": [
-    { "name": "Charlie Robbins", "email": "charlie@nodejitsu.com" },
-    { "name": "Maciej Malecki", "email": "maciej@nodejitsu.com" }
+    {
+      "name": "Charlie Robbins",
+      "email": "charlie@nodejitsu.com"
+    },
+    {
+      "name": "Maciej Malecki",
+      "email": "maciej@nodejitsu.com"
+    }
   ],
   "main": "./lib/cradle",
   "dependencies": {
@@ -17,6 +27,8 @@
   },
   "devDependencies": {
     "async": "~0.9.0",
+    "proxyquire": "^1.7.3",
+    "sinon": "^1.17.2",
     "vows": "0.8.x"
   },
   "scripts": {

--- a/test/raw-request-test.js
+++ b/test/raw-request-test.js
@@ -1,0 +1,28 @@
+var path = require('path'),
+    assert = require('assert'),
+    events = require('events'),
+    vows = require('vows'),
+    sinon = require('sinon'),
+    proxyquire = require('proxyquire');
+
+var reqSpy = sinon.spy();
+var cradle = proxyquire('../lib/cradle', {
+    request: reqSpy
+});
+
+vows.describe('cradle/raw-request').addBatch({
+  'Options specified in "request" are passed directly to request library': {
+    topic: new(cradle.Connection)({ request: { someOption: 'filler' }}),
+    'should pass through values to "request"': function(topic) {
+      var args;
+      var opts = {
+        moreOptions: 'moreFiller',
+        path: 'path'
+      };
+      topic.rawRequest(opts);
+      args = reqSpy.getCall(0).args[0];
+      assert(args.moreOptions, 'moreFiller');
+      assert(args.someOption, 'filler');
+    }
+  }
+}).export(module);


### PR DESCRIPTION
These changes were made so that users can place arbitrary config values into the *request* field when configuring a `Connection` in order to manipulate configuration values for the `request` library.

Included is a very basic unit test that tests out the `rawRequest` function to ensure these values are passed to `request` correctly.