### PR TITLE
anonymous functions with babel don't work with _design docs in couchdb.

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -197,7 +197,7 @@ cradle.Connection.prototype.request = function (options, callback) {
     if (options.body) {
         options.body = JSON.stringify(options.body, function (k, val) {
             if (typeof(val) === 'function') {
-                return val.toString();
+                return val.toString().replace(/function?\s[a-zA-Z]*/g, 'function ');
             } else { return val }
         });
         options.headers["Content-Length"] = Buffer.byteLength(options.body);


### PR DESCRIPTION
found that babel gives anonymous functions names which then get cast to a string with an identifier which breaks couchdb.

see gist for examples.
https://gist.github.com/export-mike/322e6c340294113096b6

change adds a simple replace to remove function identifier
