### PR TITLE
fix error "o.__lookupGetter__ is not a function"

### DIFF
--- a/lib/cradle.js
+++ b/lib/cradle.js
@@ -313,7 +313,7 @@ cradle.merge = function (target) {
     var objs = Array.prototype.slice.call(arguments, 1);
     objs.forEach(function (o) {
         Object.keys(o).forEach(function (attr) {
-            if (! o.__lookupGetter__(attr)) {
+            if (o.__lookupGetter__ && ! o.__lookupGetter__(attr)) {
                 target[attr] = o[attr];
             }
         });


### PR DESCRIPTION
maybe the function "cradle.merge" is called some time at edit DB.
the case when variable o is not Object, I had this error.
so, I added check that o has __lookupGetter__ .